### PR TITLE
Improve efficiency of random secret generation

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,7 +48,7 @@ chown -R letsencrypt:letsencrypt /snikket/letsencrypt
 
 ## Generate secret for coturn auth if necessary
 if ! test -f /snikket/prosody/turn-auth-secret-v2; then
-	tr -dc 'a-z0-9' < /dev/urandom | head -c32 > /snikket/prosody/turn-auth-secret-v2;
+	head -c 32 /dev/urandom | base64 > /snikket/prosody/turn-auth-secret-v2;
 fi
 
 # COMPAT w/ alpha.20200513: remove older format


### PR DESCRIPTION
Reading untold amounts of data and throwing away all except \~86% seems
wasteful.

This method reads exactly 32 bytes from /dev/urandom, while the previous
method would have stuffed pipes full before finding 32 bytes in the
specified range. All of the entropy of those 32 bytes are also kept in
the base64 form, although this is probably insane overkill.