### PR TITLE
Correct some subdomains in nginx reverse proxy documentation

### DIFF
--- a/docs/advanced/reverse_proxy.md
+++ b/docs/advanced/reverse_proxy.md
@@ -63,8 +63,8 @@ server {
   ssl_certificate_key /path/to/key.pem;
 
   server_name chat.example.com;
-  server_name groups.example.com;
-  server_name share.example.com;
+  server_name groups.chat.example.com;
+  server_name share.chat.example.com;
 
   location / {
       proxy_pass http://localhost:5080/;


### PR DESCRIPTION
From the rest of the documentation, I think the domain names in the nginx snippet should be fixed this way.