### PR TITLE
Add `/` to invite URL

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -128,7 +128,7 @@ registration_invite_only = true
 -- over what happens when a user invites someone.
 allow_contact_invites = false
 
-invites_page = ENV_SNIKKET_INVITE_URL or ("https://"..DOMAIN.."/invite/{invite.token}");
+invites_page = ENV_SNIKKET_INVITE_URL or ("https://"..DOMAIN.."/invite/{invite.token}/");
 invites_page_external = true
 
 c2s_require_encryption = true


### PR DESCRIPTION
The new portal version will support this (see [1]). The rationale
is also explained over there, but to summarize: If the link ends
in `_` or `-`, some user agents will not linkify it correctly,
worsening the UX.

   [1]: https://github.com/snikket-im/snikket-web-portal/issues/48