### PR TITLE
Improve observability

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -162,7 +162,17 @@ authentication = "internal_hashed"
 authorization = "internal"
 storage = "internal"
 statistics = "internal"
-statistics_interval = 60
+
+if ENV_SNIKKET_TWEAK_PROMETHEUS == "1" then
+	-- When using Prometheus, it is desirable to let the prometheus scraping
+	-- drive the sampling of metrics
+	statistics_interval = "manual"
+else
+	-- When not using Prometheus, we need an interval so that the metrics can
+	-- be shown by the web portal. The HTTP admin API exposure does not force
+	-- a collection as it is only interested in very few specific metrics.
+	statistics_interval = 60
+end
 
 certificates = "certs"
 
@@ -199,6 +209,12 @@ VirtualHost (DOMAIN)
 		invites_page = "/invite";
 		invites_register = "/register";
 	}
+
+	if ENV_SNIKKET_TWEAK_PROMETHEUS == "1" then
+		modules_enabled = {
+			"prometheus";
+		}
+	end
 
 	welcome_message = [[Hi, welcome to Snikket on $host! Thanks for joining us.]]
 	.."\n\n"

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -109,6 +109,9 @@ modules_enabled = {
 		"http_oauth2";
 		"http_admin_api";
 		"rest";
+
+	-- Monitoring & maintenance
+		"measure_process";
 }
 
 registration_watchers = {} -- Disable by default
@@ -159,6 +162,7 @@ authentication = "internal_hashed"
 authorization = "internal"
 storage = "internal"
 statistics = "internal"
+statistics_interval = 60
 
 certificates = "certs"
 

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       build: "1436"
     prosody_modules:
-      revision: "8e58a1b78336"
+      revision: "cade5dac1003"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -117,6 +117,7 @@
     - mod_muc_local_only
     - mod_http_host_status_check
     - mod_measure_process
+    - mod_prometheus
 
 - name: Enable wanted modules (snikket-modules)
   file:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -116,6 +116,7 @@
     - mod_muc_defaults
     - mod_muc_local_only
     - mod_http_host_status_check
+    - mod_measure_process
 
 - name: Enable wanted modules (snikket-modules)
   file:


### PR DESCRIPTION
This allows exposure of core system metrics (cpu use, memory, c2s connections) to and via the web portal by updating `mod_http_admin_api` and loading `mod_measure_process`.

For more extensive setups, it is now possible to enable Prometheus exposure using an environment variable.