### PR TITLE
Switch to mod_http_file_share

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -192,7 +192,6 @@ end
 http_default_host = DOMAIN
 http_host = DOMAIN
 http_external_url = "https://"..DOMAIN.."/"
-http_max_content_size = 1024 * 1024 * 16 -- 16MB
 
 if ENV_SNIKKET_TWEAK_TURNSERVER ~= "0" or ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN then
 	turncredentials_host = ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN or DOMAIN
@@ -252,13 +251,16 @@ Component ("groups."..DOMAIN) "muc"
 		}
 	}
 
-Component ("share."..DOMAIN) "http_upload"
+Component ("share."..DOMAIN) "http_file_share"
 	-- For backwards compat, allow HTTP upload on the base domain
 	if ENV_SNIKKET_TWEAK_SHARE_DOMAIN ~= "1" then
 		http_host = "share."..DOMAIN
 		http_external_url = "https://share."..DOMAIN.."/"
 	end
-	http_upload_file_size_limit = 1024 * 1024 * 16 -- 16MB
-	http_upload_expire_after = 60 * 60 * 24 * RETENTION_DAYS -- N days
+	http_file_share_file_size_limit = 1024 * 1024 * 16 -- 16MB
+	http_file_share_expire_after = 60 * 60 * 24 * RETENTION_DAYS -- N days
+	http_paths = {
+		file_share = "/upload"
+	}
 
 Include (ENV_SNIKKET_TWEAK_EXTRA_CONFIG or "/snikket/prosody/*.cfg.lua")

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -84,7 +84,7 @@
     - mod_block_registrations
     - mod_compact_resource
     - mod_conversejs
-    - mod_http_upload
+    - mod_migrate_http_upload
     - mod_lastlog
     - mod_limit_auth
     - mod_password_policy

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,4 +48,8 @@ if test -f /snikket/prosody/turn-auth-secret; then
 	rm /snikket/prosody/turn-auth-secret;
 fi
 
+if test -d /snikket/prosody/http_upload; then
+	prosodyctl mod_migrate_http_upload "share.$SNIKKET_DOMAIN" "$SNIKKET_DOMAIN"
+fi
+
 exec supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Includes migration from mod_http_upload and preserves existing URLs.

Primary benefit for users is likely efficient handling of much larger file uploads.

Testing with Snikket-iOS / Siskin before merging would be good.