### PR TITLE
Dockerfile: Remove apt lists at the very end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
         gpg gpg-agent \
         ansible python-passlib python3-passlib \
         libcap2-bin build-essential\
-    && rm -rf /var/lib/apt/lists/* \
     && c_rehash \
     && ansible-playbook -c local -i localhost, --extra-vars "ansible_python_interpreter=/usr/bin/python2" /opt/ansible/snikket.yml \
     && apt-get remove -y \
@@ -36,6 +35,7 @@ RUN apt-get update \
          python-passlib python3-passlib \
          mercurial libcap2-bin build-essential \
     && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/*
 
 RUN echo "Snikket $BUILD_SERIES $BUILD_ID" > /usr/lib/prosody/prosody.version


### PR DESCRIPTION
```
docker run -it --rm --network host --name tmp --entrypoint bash snikket/snikket-server:beta 
# ls -lh /var/lib/apt/lists
total 17M
drwxr-xr-x 2 _apt root 4.0K May 17 20:36 auxfiles
-rw-r--r-- 1 root root  51K May 17 20:08 deb.debian.org_debian_dists_buster-updates_InRelease
-rw-r--r-- 1 root root  19K Apr 23 13:57 deb.debian.org_debian_dists_buster-updates_main_binary-amd64_Packages.lz4
-rw-r--r-- 1 root root 119K Mar 27 10:05 deb.debian.org_debian_dists_buster_InRelease
-rw-r--r-- 1 root root  17M Mar 27 09:33 deb.debian.org_debian_dists_buster_main_binary-amd64_Packages.lz4
-rw-r----- 1 root root    0 May 17 20:36 lock
-rw-r--r-- 1 root root 7.2K May 17 16:59 packages.prosody.im_debian_dists_buster_InRelease
-rw-r--r-- 1 root root 3.5K May 17 01:30 packages.prosody.im_debian_dists_buster_main_binary-amd64_Packages.lz4
drwx------ 2 _apt root 4.0K May 17 20:37 partial
-rw-r--r-- 1 root root  64K May 17 20:35 security.debian.org_debian-security_dists_buster_updates_InRelease
-rw-r--r-- 1 root root 549K May 17 20:35 security.debian.org_debian-security_dists_buster_updates_main_binary-amd64_Packages.lz4
```

Doing this after the Ansible step should ensure that they are gone even if Ansible happens to re-fetch them for some, which appears to be the case.

This also fixes that Ansible is unable to install Lua if Ansible is switched over to Python 3. The list files are likely needed by APT to install packages, so it probably only worked because it somehow re-fetched them.