### PR TITLE
Remove some cruft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
         libcap2-bin build-essential\
     && c_rehash \
     && ansible-playbook -c local -i localhost, --extra-vars "ansible_python_interpreter=/usr/bin/python2" /opt/ansible/snikket.yml \
-    && apt-get remove -y \
+    && apt-get remove --purge -y \
          ansible \
          software-properties-common \
          gpg gpg-agent \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
          gpg gpg-agent \
          python-passlib python3-passlib \
          mercurial libcap2-bin build-essential \
+         python3 python3.7-minimal \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/*


### PR DESCRIPTION
APT leaves some cruft behind, mostly `/etc/python3` and `/etc/python3.7`. These are small but are supposed to be removed.