### PR TITLE
Update base image to Debian 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG BUILD_SERIES=dev
 ARG BUILD_ID=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get update \
          gpg gpg-agent \
          python3-passlib \
          mercurial libcap2-bin build-essential \
-         python3 python3.7-minimal \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/*

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -142,44 +142,8 @@
     state: present
     install_recommends: no
 
-- name: "Fetch luaunbound source"
-  get_url:
-    #url: https://code.zash.se/dl/luaunbound/luaunbound-0.5.tar.gz
-    url: https://matthewwild.co.uk/uploads/luaunbound-0.5.tar.gz
-    sha256sum: a6564ac1cca6bb350576eb2a5cfa03adb0aafd4f99d6cd491bd8028d046c62a7
-    dest: /tmp/luaunbound-0.5.tar.gz
-
-- name: "Extract luaunbound"
-  unarchive:
-    src: /tmp/luaunbound-0.5.tar.gz
-    remote_src: yes
-    dest: /tmp
-
-- name: "Install libunbound-dev"
-  apt:
-    name:
-      - libunbound8
-      - libunbound-dev
-      - liblua5.2-dev
-    state: present
-
-- name: "Build luaunbound"
-  make:
-    chdir: /tmp/luaunbound-0.5
-
 - name: "Install luaunbound"
-  make:
-    chdir: /tmp/luaunbound-0.5
-    target: install
-
-- name: "Remove luaunbound source"
-  file:
-    path: /tmp/luaunbound-0.5
-    state: absent
-
-- name: "Remove libunbound-dev"
   apt:
-    name:
-      - libunbound-dev
-      - liblua5.2-dev
-    state: absent
+    name: lua-unbound
+    state: present
+    install_recommends: no

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -11,13 +11,13 @@
 - name: "Add Prosody package repo"
   apt_repository:
     filename: prosody
-    repo: "deb https://packages.prosody.im/debian buster main"
+    repo: "deb https://packages.prosody.im/debian bullseye main"
 - name: "Detect dpkg architecture name"
   shell: dpkg --print-architecture
   register: dpkg_arch
 - name: "Install Prosody package"
   apt:
-    deb: "https://packages.prosody.im/debian/pool/main/p/{{ prosody.package }}/{{ prosody.package }}_1nightly{{ prosody.build }}-1~buster_{{ dpkg_arch.stdout }}.deb"
+    deb: "https://packages.prosody.im/debian/pool/main/p/{{ prosody.package }}/{{ prosody.package }}_1nightly{{ prosody.build }}-1~bullseye_{{ dpkg_arch.stdout }}.deb"
     state: present
     install_recommends: yes
 - name: "Deploy Prosody config"


### PR DESCRIPTION
Rationale: The number of lines removed. This is primarily because lua-unbound is packaged so doesn't need to be built from source.