### PR TITLE
Fix create-invite --qr

### DIFF
--- a/ansible/files/bin/create-invite
+++ b/ansible/files/bin/create-invite
@@ -3,6 +3,7 @@
 SHOW_QR=0
 if [ "$1" == "--qr" ]; then
 	SHOW_QR=1;
+	shift;
 fi
 
 URL=$(prosodyctl mod_invites generate "$SNIKKET_DOMAIN" "$@")

--- a/ansible/tasks/scripts.yml
+++ b/ansible/tasks/scripts.yml
@@ -5,3 +5,8 @@
     src: "../files/bin/"
     dest: "/usr/local/bin/"
     mode: 0755
+
+- name: "Install qrencode"
+  apt:
+    name: qrencode
+    state: present


### PR DESCRIPTION
1. `qrencode` was not installed
2. the `--qr` flag was not removed after being parsed, so got passed to `prosodyctl` which it doesn't like.