### PR TITLE
Make maximum upload file size configurable

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -1,6 +1,7 @@
 local DOMAIN = assert(ENV_SNIKKET_DOMAIN, "Please set the SNIKKET_DOMAIN environment variable")
 
 local RETENTION_DAYS = tonumber(ENV_SNIKKET_RETENTION_DAYS) or 7;
+local MAX_FILE_SIZE_MB = tonumber(ENV_SNIKKET_TWEAK_MAX_FILE_SIZE_MB) or 16;
 
 if prosody.process_type == "prosody" and not prosody.config_loaded then
 	-- Wait at startup for certificates
@@ -261,7 +262,7 @@ Component ("share."..DOMAIN) "http_file_share"
 		http_host = "share."..DOMAIN
 		http_external_url = "https://share."..DOMAIN.."/"
 	end
-	http_file_share_size_limit = 1024 * 1024 * 16 -- 16MB
+	http_file_share_size_limit = 1024 * 1024 * MAX_FILE_SIZE_MB -- N MB
 	http_file_share_expire_after = 60 * 60 * 24 * RETENTION_DAYS -- N days
 	http_paths = {
 		file_share = "/upload"

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -261,7 +261,7 @@ Component ("share."..DOMAIN) "http_file_share"
 		http_host = "share."..DOMAIN
 		http_external_url = "https://share."..DOMAIN.."/"
 	end
-	http_file_share_file_size_limit = 1024 * 1024 * 16 -- 16MB
+	http_file_share_size_limit = 1024 * 1024 * 16 -- 16MB
 	http_file_share_expire_after = 60 * 60 * 24 * RETENTION_DAYS -- N days
 	http_paths = {
 		file_share = "/upload"

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -72,6 +72,16 @@ The TCP port on which the internal HTTP API listens on. The default is `5280`. D
 
 The IP address on which the internal HTTP API listens on. The default is `127.0.0.1`, so that the API is only accessible from the same server. Changing this may be a security risk as some general system information is accessible without authentication.
 
+### `SNIKKET_TWEAK_MAX_FILE_SIZE_MB`
+
+The maximum file size users can upload to this server (per file) in units of MiB (1048576 bytes). The default is 16 (so 16 MiB maximum file size).
+
+Files are stored for `SNIKKET_RETENTION_DAYS` days on the server, so increasing this limit also increases the storage use (even though users could simply upload many small files to exhaust storage, a larger limit likely encourages uploading larger files). As with text messages, uploaded files are by default encrypted by the apps, so they are not stored without encryption at the server.
+
+On the other hand, users may expect to be able to share large files (for instance, videos) even in groups (where peer-to-peer transfer is not available), so some instances will want to increase it.
+
+(In the future, there may be a way to set a daily and overall quota, at which point the options may be promoted to non-tweak level.)
+
 ### `SNIKKET_INVITE_URL`
 
 The URL template for invitation links. The server needs to know under which address the invitation service is hosted.


### PR DESCRIPTION
This has been requested many times in the support channel and I can
fully understand it. Now with mod_http_file_share, the limit can safely
be raised (aside from disk storage requirements), so let's give users a
knob to play with.

(Note how I changed the previously incorrect option name in a separete commit.)