### PR TITLE
Fix incorrect config option

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -261,7 +261,7 @@ Component ("share."..DOMAIN) "http_file_share"
 		http_host = "share."..DOMAIN
 		http_external_url = "https://share."..DOMAIN.."/"
 	end
-	http_file_share_file_size_limit = 1024 * 1024 * 16 -- 16MB
+	http_file_share_size_limit = 1024 * 1024 * 16 -- 16MB
 	http_file_share_expire_after = 60 * 60 * 24 * RETENTION_DAYS -- N days
 	http_paths = {
 		file_share = "/upload"


### PR DESCRIPTION
Both the docs [1] and the code [2] of mod_http_file_share agree that it
should be `http_file_share_size_limit`, not
`http_file_share_file_size_limit`.

   [1]: https://prosody.im/doc/modules/mod_http_file_share#larger-files
   [2]: https://hg.prosody.im/trunk/file/default/plugins/mod_http_file_share.lua#l35