### PR TITLE
mod_snikket_restricted_users: Don't isolate users with no roles

### DIFF
--- a/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
+++ b/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
@@ -9,7 +9,8 @@ local function load_main_host(module)
 		if not session.no_host_isolation then
 			local bare_jid = jid_bare(session.full_jid);
 			local roles = um_get_roles(bare_jid, module.host);
-			if roles and not roles["prosody:restricted"] then
+			if roles == false then return; end
+			if not roles or not roles["prosody:restricted"] then
 				-- Bypass isolation for all unrestricted users
 				session.no_host_isolation = true;
 			end


### PR DESCRIPTION
The code was originally written to fail safe in the event of failure, hence
the 'if roles and ...'. However a user with no roles (which is normal for a
normal user, especially on upgrade) can return nil.

Failure is signified by 'false', so now we explicitly catch this and return
early without bypassing isolation. Users with no roles (nil) or with roles
but not prosody:restricted bypass isolation.