### PR TITLE
prosody: Tune GC to be more aggressive by default

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -29,6 +29,11 @@ data_path = "/snikket/prosody"
 
 pidfile = "/var/run/prosody/prosody.pid"
 
+-- Aggressive GC to reduce resource consumption. These values are not
+-- incredibly scientific, but should be good for a small private server.
+-- They should be reviewed on the upgrade to Lua 5.4.
+gc = { threshold = 100, speed = 750 }
+
 modules_enabled = {
 
 	-- Generally required


### PR DESCRIPTION
It appears that, in some environments at least, large file uploads can still
cause a significant increase in RAM. This reduces that effect.

It is expected that a future release will switch to Lua 5.4, which has shown
to have far better GC behaviour.