### PR TITLE
prosody: Show Snikket domain in admin shell prompt

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -29,6 +29,8 @@ data_path = "/snikket/prosody"
 
 pidfile = "/var/run/prosody/prosody.pid"
 
+admin_shell_prompt = ("prosody [%s]> "):format(DOMAIN)
+
 -- Aggressive GC to reduce resource consumption. These values are not
 -- incredibly scientific, but should be good for a small private server.
 -- They should be reviewed on the upgrade to Lua 5.4.

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,7 +7,7 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      build: "1535"
+      build: "1537"
     prosody_modules:
       revision: "8bd36bba2292"
   tasks:


### PR DESCRIPTION
This allows easier verification that you are issuing commands to the right Prosody instance.