### PR TITLE
Fix restricted users

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -83,6 +83,7 @@ modules_enabled = {
 		"isolate_host";
 		"snikket_client_id";
 		"snikket_ios_preserve_push";
+		"snikket_restricted_users";
 
 	-- Spam/abuse management
 		"spam_reporting"; -- Allow users to report spam/abuse

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,7 +7,7 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      build: "1535"
+      build: "1540"
     prosody_modules:
       revision: "8bd36bba2292"
   tasks:


### PR DESCRIPTION
- Forgot to load mod_snikket_restricted_users on the main host (oops), this is now fixed
- Prosody has been updated to kick current sessions when a user's role is modified. This means role changes now take effect immediately, instead of whenever the user happens to reconnect.