### PR TITLE
prosody: Enable push notifications for offline group members by default

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -250,6 +250,7 @@ Component ("groups."..DOMAIN) "muc"
 		"muc_defaults";
 		"muc_offline_delivery";
 		"snikket_restricted_users";
+		"muc_auto_reserve_nicks";
 	}
 	restrict_room_creation = "local"
 	muc_local_only = { "general@groups."..DOMAIN }
@@ -258,6 +259,10 @@ Component ("groups."..DOMAIN) "muc"
 	muc_room_default_allow_member_invites = true
 	muc_room_default_persistent = true
 	muc_room_default_public = false
+
+	-- Enable push notifications for offline group members by default
+	-- (this also requires mod_muc_auto_reserve_nicks in practice)
+	muc_offline_delivery_default = true
 
 	default_mucs = {
 		{

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,9 +7,9 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      build: "1540"
+      build: "1544"
     prosody_modules:
-      revision: "8bd36bba2292"
+      revision: "eb63890ae8fc"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -124,6 +124,7 @@
     - mod_spam_reporting
     - mod_watch_spam_reports
     - mod_isolate_host
+    - mod_muc_auto_reserve_nicks
 
 - name: Enable wanted modules (snikket-modules)
   file:


### PR DESCRIPTION
This avoids the app needing to gain logic to opt-in to push notifications.
Such logic may be fragile, and introduce additional traffic and round-trips
that would hurt performance.

Note that this will trigger pushes even to users who only use Android or
non-mobile devices. That should cause no issues, and the impact would be
minor. Also considering that non-iOS devices usually remain online most of the
time anyway.

Not accounted for in this commit is the MUC notification filtering side of
things. By default the MUC will push all messages, and
mod_cloud_notify(_filters) will allow all of them through to the device unless
the user explicitly configures otherwise within the app.

If the server can detect whether a MUC is public or private, it can make the
default behaviour more sensible (maybe when adding bookmarks or something?).
In any case, public channels are not a primary use-case for Snikket and can
easily be configured manually in the app for now.