### PR TITLE
Feature: measure active users

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -127,6 +127,7 @@ modules_enabled = {
 
 	-- Monitoring & maintenance
 		"measure_process";
+		"measure_active_users";
 }
 
 registration_watchers = {} -- Disable by default

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -86,6 +86,7 @@ modules_enabled = {
 		"snikket_client_id";
 		"snikket_ios_preserve_push";
 		"snikket_restricted_users";
+		"lastlog2";
 
 	-- Spam/abuse management
 		"spam_reporting"; -- Allow users to report spam/abuse

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       build: "1544"
     prosody_modules:
-      revision: "eb63890ae8fc"
+      revision: "1132f2888cd2"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -125,6 +125,7 @@
     - mod_watch_spam_reports
     - mod_isolate_host
     - mod_muc_auto_reserve_nicks
+    - mod_measure_active_users
 
 - name: Enable wanted modules (snikket-modules)
   file:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -87,7 +87,7 @@
     - mod_compact_resource
     - mod_conversejs
     - mod_migrate_http_upload
-    - mod_lastlog
+    - mod_lastlog2
     - mod_limit_auth
     - mod_password_policy
     - mod_roster_allinall


### PR DESCRIPTION
**Switch to and enable mod_lastlog2**

This records a timestamp of various account events - account registration
time, last connection and last disconnection.

In the future I would like to keep a time-limited record of account activity
so we can also present it to the user for security purposes (e.g. detecting
account compromise and access by third-parties). That will need additional
design work to figure out how to do it in a privacy-preserving way.

**prosody: Enable mod_measure_active_users**

This allows an operator (via Prometheus, or eventually the web portal) to keep
tabs on how many people are actively using the server, e.g. to assist with capacity
planning. This will become more important once we allow user-to-user account
invitations.