### PR TITLE
More memory metrics!

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -129,6 +129,7 @@ modules_enabled = {
 		"measure_process";
 		"measure_active_users";
 		"measure_lua";
+		"measure_malloc";
 }
 
 registration_watchers = {} -- Disable by default

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -128,6 +128,7 @@ modules_enabled = {
 	-- Monitoring & maintenance
 		"measure_process";
 		"measure_active_users";
+		"measure_lua";
 }
 
 registration_watchers = {} -- Disable by default

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -127,6 +127,7 @@
     - mod_muc_auto_reserve_nicks
     - mod_measure_active_users
     - mod_measure_lua
+    - mod_measure_malloc
 
 - name: Enable wanted modules (snikket-modules)
   file:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -126,6 +126,7 @@
     - mod_isolate_host
     - mod_muc_auto_reserve_nicks
     - mod_measure_active_users
+    - mod_measure_lua
 
 - name: Enable wanted modules (snikket-modules)
   file:


### PR DESCRIPTION
Glorious statistics! RSS is already collected (by `mod_measure_process`), but that need have no relation to actual memory usage in any way, swapped out memory does not count, while unused (by malloc) memory does.. maybe.