### PR TITLE
prosody: enable muc_registration_include_form

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -265,6 +265,9 @@ Component ("groups."..DOMAIN) "muc"
 	-- Enable push notifications for offline group members by default
 	-- (this also requires mod_muc_auto_reserve_nicks in practice)
 	muc_offline_delivery_default = true
+	-- Include form in MUC registration query result (required for app
+	-- to detect whether push notifications are enabled)
+	muc_registration_include_form = true
 
 	default_mucs = {
 		{


### PR DESCRIPTION
This is required for the app to learn of the current registration status (in detail). Without it, the 'push notifications' toggle is always off and disabled.