### PR TITLE
mod_update_check: Fix for unbound API difference

### DIFF
--- a/snikket-modules/mod_update_check/mod_update_check.lua
+++ b/snikket-modules/mod_update_check/mod_update_check.lua
@@ -32,7 +32,7 @@ function check_for_updates()
 		local result = {};
 		for _, record in ipairs(records) do
 			if record.txt then
-				local key, val = record.txt:match("(%S+)=(%S+)");
+				local key, val = tostring(record.txt):match("(%S+)=(%S+)");
 				if key then
 					result[key] = val;
 				end


### PR DESCRIPTION
TXT records can consist of multiple length-prefixed strings, terminated
by a zero-length string, but in most cases there is simply one.

When not using luaunbound, `record.txt` was always the first of those
strings, which should be considered a bug in [dns.lua](https://hg.prosody.im/trunk/file/7a48ccb084dd/net/dns.lua#l608). Prosodys [net.dns](https://hg.prosody.im/trunk/file/7a48ccb084dd/util/dns.lua)
translates it to an array of strings, which means this code tried to
call `match` on an array instead of a string, causing an error. These
arrays have a [metatable](https://hg.prosody.im/trunk/file/7a48ccb084dd/util/dns.lua#l196) with a `__tostring` field set to `table.concat`,
so just passing this string or array trough tostring should always
produce a sensible string.