### PR TITLE
Switch to new Direct TLS setting

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -140,7 +140,7 @@ http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "127.0.0.1" }
 
 https_ports = {};
 
-legacy_ssl_ports = { 5223 }
+c2s_direct_tls_ports = { 5223 }
 
 allow_registration = true
 registration_invite_only = true


### PR DESCRIPTION
While these settings themselves are functionally identical, the new one
has additional support from e.g. `prosodyctl check` and also a name not
mentioning "legacy" :)

Requires https://hg.prosody.im/trunk/rev/f254fd16218a or later