### PR TITLE
prosody: Remove unused mod_default_bookmarks

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -77,7 +77,6 @@ modules_enabled = {
 		"email";
 		"http_altconnect";
 		"bookmarks";
-		"default_bookmarks";
 		"update_check";
 		"update_notify";
 		"turncredentials";

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -97,7 +97,6 @@
     - mod_email
     - mod_http_altconnect
     - mod_bookmarks
-    - mod_default_bookmarks
     - mod_firewall
     - mod_turncredentials
     - mod_admin_notify


### PR DESCRIPTION
It was replaced by the circle modules and the configuration was removed in d6b2676829adea15347ca52645f3b9858223047d

This is also in preparation of switching to mod_bookmarks2 / XEP-0402