### PR TITLE
scripts: Use stricter POSIX shell

### DIFF
--- a/ansible/files/bin/cert-monitor.sh
+++ b/ansible/files/bin/cert-monitor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -e
 
 CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/cert.pem"
 

--- a/ansible/files/bin/create-invite
+++ b/ansible/files/bin/create-invite
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh -e
 
 SHOW_QR=0
-if [ "$1" == "--qr" ]; then
+if [ "$1" = "--qr" ]; then
 	SHOW_QR=1;
 	shift;
 fi

--- a/ansible/files/bin/start-coturn.sh
+++ b/ansible/files/bin/start-coturn.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 if [ "$SNIKKET_TWEAK_TURNSERVER" = "0" ]; then
 	echo "TURN server disabled by environment, not launching.";


### PR DESCRIPTION
Bash does not appear to be strictly required here, so better to use strict POSIX shell