### PR TITLE
scripts: Look for chain instead of bare cert

### DIFF
--- a/ansible/files/bin/cert-monitor.sh
+++ b/ansible/files/bin/cert-monitor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/cert.pem"
+CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/fullchain.pem"
 
 if test -f "$CERT_PATH"; then
 	prosodyctl --root cert import /snikket/letsencrypt/live


### PR DESCRIPTION
This is the file that we are waiting for. The cert file might
theoretically be created before the chain, leading to a race condition.

Discovered because I pointed it at directory where I had manually
created only fullchain and privkey.pem