### PR TITLE
turnserver: add support for CNAMEs on the Snikket domain

### DIFF
--- a/ansible/files/bin/snikket-turn-addresses
+++ b/ansible/files/bin/snikket-turn-addresses
@@ -15,10 +15,22 @@ local ip_addr = ip.new_ip(addresses[1]);
 if not ip_addr.private then
 	-- Not a private address, no mapping needed
 	print(ip_addr);
-else
-	local dns_record = dns.lookup(arg[1], ip_addr.proto == "IPv6" and "AAAA" or "A");
-	if #dns_record == 0 then
-		os.exit(1);
-	end
-	print(dns_record[1].a.."/"..tostring(ip_addr));
+	os.exit(0)
 end
+
+-- follow at most 3 CNAMEs (arbitrary choice)
+local final_record = arg[1];
+for i=1,3 do
+	local reply = dns.lookup(final_record, "CNAME");
+	if not reply or #reply== 0 then
+		break
+	end
+	local dest = reply[1].cname;
+	io.stderr:write(string.format("following CNAME %s -> %s\n", final_record, dest))
+	final_record = dest;
+end
+local dns_record = dns.lookup(final_record, ip_addr.proto == "IPv6" and "AAAA" or "A")
+if not dns_record or #dns_record == 0 then
+	os.exit(1);
+end
+print(dns_record[1].a.."/"..tostring(ip_addr));


### PR DESCRIPTION
I have that on my test domain and I think this should be a supported
case. In non-APEX cases, that would be a valid way to use the hosting
service.