### PR TITLE
Update prosody to latest trunk

### DIFF
--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,9 +7,9 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      build: "1590"
+      build: "1592"
     prosody_modules:
-      revision: "5fadb991003d"
+      revision: "fdf50c4d23a3"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml


### PR DESCRIPTION
That contains some defensive compatibility fixes for mod_bookmarks. Also
we need to update prosody modules to include the compatibility fixes for
mod_groups_muc_bookmarks