### PR TITLE
Fix to support live PEP importing

### DIFF
--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       build: "1598"
     prosody_modules:
-      revision: "541b2cf68e93"
+      revision: "0f5f2d4475b9"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml


### PR DESCRIPTION
Bumps prosody-modules for 0f5f2d4475b9, so that the web portal (and XMPP clients) will show imported PEP data immediately, even if Prosody currently has it cached in RAM.