### PR TITLE
Remove mod_reload_modules

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -99,7 +99,6 @@ modules_enabled = {
 		--"motd"; -- Send a message to users when they log in
 		"welcome"; -- Welcome users who register accounts
 		"http_files"; -- Serve static files from a directory over HTTP
-		"reload_modules";
 
 	-- Invites
 		"invites";
@@ -134,8 +133,6 @@ modules_enabled = {
 
 registration_watchers = {} -- Disable by default
 registration_notification = "New user registered: $username"
-
-reload_global_modules = { "http" }
 
 http_ports  = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_PORT or 5280 }
 http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "127.0.0.1" }

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -92,7 +92,6 @@
     - mod_roster_allinall
     - mod_strict_https
     - mod_vcard_muc
-    - mod_reload_modules
     - mod_email
     - mod_http_altconnect
     - mod_firewall


### PR DESCRIPTION
Assuming the purpose was to refresh renewed certificates by reloading mod_http, this is redundant since https is no longer handled by Prosody but by snikket-web-proxy since 280fabb6527bb37bc13d20a239f52ec36799d509.

If there is another purpose to using this mod_reload_modules then this can be rejected.