### PR TITLE
Check health of container via Prosody shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD docker/entrypoint.sh /bin/entrypoint.sh
 RUN chmod 770 /bin/entrypoint.sh
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-HEALTHCHECK CMD lua -l socket -e 'assert(socket.connect(os.getenv"SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE" or "127.0.0.1",os.getenv"SNIKKET_TWEAK_INTERNAL_HTTP_PORT" or "5280"))'
+HEALTHCHECK CMD /usr/bin/prosodyctl shell "portcheck ${SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE:-127.0.0.1}:${SNIKKET_TWEAK_INTERNAL_HTTP_PORT:-5280}"
 
 ADD ansible /opt/ansible
 

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -129,6 +129,7 @@ modules_enabled = {
 		"measure_active_users";
 		"measure_lua";
 		"measure_malloc";
+		"portcheck";
 }
 
 registration_watchers = {} -- Disable by default

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       snapshot: "2022-06-07"
     prosody_modules:
-      revision: "0f5f2d4475b9"
+      revision: "42a362a2bf51"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -118,6 +118,7 @@
     - mod_measure_lua
     - mod_measure_malloc
     - mod_http_xep227
+    - mod_portcheck
 
 - name: Enable wanted modules (snikket-modules)
   file:


### PR DESCRIPTION
This is two-fold.
Firstly, if Prosody is not running then `prosodyctl shell` should fail there, signaling unhealth.
Secondly, the new [mod_portcheck](https://modules.prosody.im/mod_portcheck.html) reports whether the Prosody in this container instance is listening on the port.

This fixes false positive health checks that would notice that a different Prosody or other XMPP server is listening on port 5280.
Because host networking is used, something listening on port 5280 on the host machine would be visible and stopping Prosody in the container from binding to that port, and possibly others.

This can later be expanded to checking other ports, such as the xmpp-client/5222 and xmpp-server/5269 etc.

**Not tested** because podman doesn't seem to support health checks or does in a way I don't understand yet.
I'm especially uncertain whether the variable interpolation used will work as intended.