### PR TITLE
prosody: Enable readline support in the Shell

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -144,3 +144,9 @@
     name: lua-unbound
     state: present
     install_recommends: no
+
+- name: "Install lua-readline"
+  apt:
+    name: lua-readline
+    state: present
+    install_recommends: no


### PR DESCRIPTION
Editing a command with readline is a more of pleasant experience than without.