### PR TITLE
prosody: Add tweak enabling DNSSEC support in resolver

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -194,6 +194,14 @@ else
 	statistics_interval = 60
 end
 
+if ENV_SNIKKET_TWEAK_DNSSEC == "1" then
+	local trustfile = "/usr/share/dns/root.ds"; -- Requires apt:dns-root-data
+	-- Bail out if it doesn't work
+	assert(require"lunbound".new{ resolvconf = true; trustfile = trustfile }:resolve ".".secure,
+		"Upstream DNS resolver is not DNSSEC-capable. Fix this or disable SNIKKET_TWEAK_DNSSEC");
+	unbound = { trustfile = trustfile }
+end
+
 certificates = "certs"
 
 group_default_name = ENV_SNIKKET_SITE_NAME or DOMAIN

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -149,3 +149,9 @@
     name: lua-readline
     state: present
     install_recommends: no
+
+- name: "Install DNS root data (for DNSSEC keys)"
+  apt:
+    name: dns-root-data
+    state: present
+    install_recommends: no

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -143,6 +143,10 @@ Expose the file share service at the `SNIKKET_DOMAIN` instead of at `share.SNIKK
 
 This nowadays conflicts with the web portal, so you should not set it.
 
+### `SNIKKET_TWEAK_DNSSEC`
+
+Enable DNSSEC support. Requires a DNSSEC-capable resolver.
+
 ### `SNIKKET_TWEAK_EXTRA_CONFIG`
 
 Path or glob for extra configuration files to load.


### PR DESCRIPTION
Prosody uses libunbound via luaunbound, which supports DNSSEC but needs
to be pointed at the root zone keys in order to activate it.

Added as a tweak initially since DNSSEC support in resolvers is
currently unknown, so can be enabled by interested users to test and
report back.