### PR TITLE
ansible: Use TWEAK domain if available

### DIFF
--- a/ansible/files/bin/cert-monitor.sh
+++ b/ansible/files/bin/cert-monitor.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CERT_PATH="/snikket/letsencrypt/live/$SNIKKET_DOMAIN/cert.pem"
+DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-SNIKKET_DOMAIN}
+CERT_PATH="/snikket/letsencrypt/live/$DOMAIN/cert.pem"
 
 if test -f "$CERT_PATH"; then
 	prosodyctl --root cert import /snikket/letsencrypt/live

--- a/ansible/files/bin/cert-monitor.sh
+++ b/ansible/files/bin/cert-monitor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-SNIKKET_DOMAIN}
+DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-$SNIKKET_DOMAIN}
 CERT_PATH="/snikket/letsencrypt/live/$DOMAIN/cert.pem"
 
 if test -f "$CERT_PATH"; then

--- a/ansible/files/bin/create-invite
+++ b/ansible/files/bin/create-invite
@@ -6,7 +6,7 @@ if [ "$1" == "--qr" ]; then
 	shift;
 fi
 
-DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-SNIKKET_DOMAIN}
+DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-$SNIKKET_DOMAIN}
 URL=$(prosodyctl mod_invites generate "$DOMAIN" "$@")
 
 echo ""

--- a/ansible/files/bin/create-invite
+++ b/ansible/files/bin/create-invite
@@ -6,7 +6,8 @@ if [ "$1" == "--qr" ]; then
 	shift;
 fi
 
-URL=$(prosodyctl mod_invites generate "$SNIKKET_DOMAIN" "$@")
+DOMAIN=${SNIKKET_TWEAK_XMPP_DOMAIN:-SNIKKET_DOMAIN}
+URL=$(prosodyctl mod_invites generate "$DOMAIN" "$@")
 
 echo ""
 echo "Your invite link: $URL"


### PR DESCRIPTION
If TWEAK domain is set, use it to create invites and in the cert monitor
to import into prosody.