### PR TITLE
Fix snapshot distribution to Debian 11

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -11,7 +11,7 @@
 - name: "Add Prosody package repo"
   apt_repository:
     filename: prosody
-    repo: "deb https://packages.prosody.im/debian buster/snapshots/{{ prosody.snapshot }} main"
+    repo: "deb https://packages.prosody.im/debian bullseye/snapshots/{{ prosody.snapshot }} main"
 - name: "Install Prosody package"
   apt:
     name: "{{ prosody.package }}"


### PR DESCRIPTION
So PR #55 was opened back in the Debian 10 "buster" days, before the
switch to Debian 11 "bullseye" and I apparently missed this when bumping
the snapshot date.