### PR TITLE
prosody: Reduce non-streaming HTTP uploads from 10MB to 1MB

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -136,6 +136,7 @@ registration_notification = "New user registered: $username"
 
 http_ports  = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_PORT or 5280 }
 http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "127.0.0.1" }
+http_max_content_size = 1024 * 1024 -- non-streaming uploads limited to 1MB (improves RAM usage)
 
 https_ports = {};
 


### PR DESCRIPTION
This improves memory usage significantly on small servers, as it will now cause uploads over 1MB to use streaming mode or (if streaming unsupported) just reject them.

This may have an impact on large BOSH payloads. For example, if setting a large avatar. However such an avatar is likely too large for the network anyway, and should be reduced by clients before upload.