### PR TITLE
mod_snikket_restricted_users: Replace with config

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -161,6 +161,12 @@ c2s_require_encryption = true
 s2s_require_encryption = true
 s2s_secure_auth = true
 
+add_permissions = {
+	["prosody:user"] = {
+		"xmpp:federate";
+	};
+}
+
 archive_expires_after = ("%dd"):format(RETENTION_DAYS) -- Remove archived messages after N days
 
 -- Disable IPv6 by default because Docker does not

--- a/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
+++ b/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
@@ -1,27 +1,5 @@
 local um_get_jid_role = require "core.usermanager".get_jid_role;
 
--- TODO replace by permission configuration
-
-local function load_main_host(module)
-	-- Check whether a user should be isolated from remote JIDs
-	-- If not, set a session flag that allows them to bypass mod_isolate_host
-	local function check_user_isolated(event)
-		local session = event.session;
-		if not session.no_host_isolation then
-			local role = session.role;
-			if not role then return; end
-			if role.name ~= "prosody:restricted" then
-				-- Bypass isolation for all unrestricted users
-				session.no_host_isolation = true;
-			end
-		end
-	end
-
-	-- Add low-priority hook to run after the check_user_isolated default
-	-- behaviour in mod_isolate_host
-	module:hook("resource-bind", check_user_isolated, -0.5);
-end
-
 local function load_groups_host(module)
 	local primary_host = module.host:gsub("^%a+%.", "");
 
@@ -50,6 +28,4 @@ end
 
 if module:get_host_type() == "component" and module:get_option_string("component_module") == "muc" then
 	load_groups_host(module);
-else
-	load_main_host(module);
 end


### PR DESCRIPTION
With the newer authz and role stuff in Prosody it is possible to configure permissions various roles should have, and thus a newer version of [mod_isolate_host](https://modules.prosody.im/mod_isolate_host.html) allows turning half of mod_snikket_restricted_users into this one config directive.

Testing needed because the authz permission usage usage in mod_isolate_host is new and there may be edge cases.