### PR TITLE
Fix installing split supervisor config

### DIFF
--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -11,8 +11,8 @@
     prosody_modules:
       revision: "5178c13deb78"
   tasks:
-    - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml
+    - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/cron.yml
     - import_tasks: tasks/certs.yml
     - import_tasks: tasks/mail.yml

--- a/ansible/tasks/certs.yml
+++ b/ansible/tasks/certs.yml
@@ -8,5 +8,5 @@
 
 - name: Add to supervisord
   copy:
-    path: /etc/supervisor/conf.d/supervisord.conf
+    dest: /etc/supervisor/conf.d/supervisord.conf
     src: ../files/supervisor-certmon.conf

--- a/ansible/tasks/coturn.yml
+++ b/ansible/tasks/coturn.yml
@@ -32,6 +32,6 @@
     mode: 0755
 
 - name: "Add to supervisord"
-  file:
-    path: /etc/supervisor/conf.d/coturn.conf
+  copy:
+    dest: /etc/supervisor/conf.d/coturn.conf
     src: ../files/supervisor-coturn.conf

--- a/ansible/tasks/cron.yml
+++ b/ansible/tasks/cron.yml
@@ -15,6 +15,6 @@
     - passwd
 
 - name: "Add to supervisord"
-  file:
-    path: /etc/supervisor/conf.d/anacron.conf
+  copy:
+    dest: /etc/supervisor/conf.d/anacron.conf
     src: ../files/supervisor-anacron.conf

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -155,6 +155,6 @@
     install_recommends: no
 
 - name: "Add to supervisord"
-  file:
-    path: /etc/supervisor/conf.d/prosody.conf
+  copy:
+    dest: /etc/supervisor/conf.d/prosody.conf
     src: ../files/supervisor-prosody.conf


### PR DESCRIPTION
Fixes [ansible error, "src option requires state to be 'link' or 'hard'"](https://buildbot.snikket.org/#/builders/19/builds/67) by using the same directive as in the other places that install supervisor settings.