### PR TITLE
Fix Lua 5.4 performance

### DIFF
--- a/ansible/files/bin/snikket-turn-addresses
+++ b/ansible/files/bin/snikket-turn-addresses
@@ -1,13 +1,10 @@
 #!/usr/bin/env lua
 
-package.path = package.path:gsub("([^;]*)(?[^;]*)","%1prosody/%2;%1%2");
-package.cpath = package.cpath:gsub("([^;]*)(?[^;]*)","%1prosody/%2;%1%2");
+package.loaded["prosody.net.server"] = require "prosody.net.server_epoll";
 
-package.loaded["net.server"] = require "net.server_epoll";
-
-local net = require "util.net";
-local ip = require "util.ip";
-local dns = require "net.unbound".dns;
+local net = require "prosody.util.net";
+local ip = require "prosody.util.ip";
+local dns = require "prosody.net.unbound".dns;
 
 local host_name = assert(arg[1], "no domain specified");
 local addresses = net.local_addresses();

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -31,11 +31,6 @@ pidfile = "/var/run/prosody/prosody.pid"
 
 admin_shell_prompt = ("prosody [%s]> "):format(DOMAIN)
 
--- Aggressive GC to reduce resource consumption. These values are not
--- incredibly scientific, but should be good for a small private server.
--- They should be reviewed on the upgrade to Lua 5.4.
-gc = { threshold = 100, speed = 750 }
-
 modules_enabled = {
 
 	-- Generally required

--- a/ansible/files/supervisord.conf
+++ b/ansible/files/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:prosody]
-command=/usr/bin/lua5.4 /usr/bin/prosody -F
+command=/usr/bin/lua5.2 /usr/bin/prosody -F
 priority=1000
 autorestart=true
 stopwaitsecs=30

--- a/ansible/files/supervisord.conf
+++ b/ansible/files/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:prosody]
-command=/usr/bin/lua5.2 /usr/bin/prosody -F
+command=/usr/bin/lua5.4 /usr/bin/prosody -F
 priority=1000
 autorestart=true
 stopwaitsecs=30

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -5,6 +5,8 @@
     name: lua5.4
     state: present
     install_recommends: no
+- name: "Use Lua 5.4 by default"
+  command: update-alternatives --set lua-interpreter /usr/bin/lua5.4
 - name: "Add Prosody package signing key"
   apt_key:
     url: "https://packages.prosody.im/debian/pubkey.asc"

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: "Install Lua 5.2"
+- name: "Install Lua 5.4"
   apt:
-    name: lua5.2
+    name: lua5.4
     state: present
     install_recommends: no
-- name: "Use Lua 5.2 by default"
-  command: update-alternatives --set lua-interpreter /usr/bin/lua5.2
+- name: "Use Lua 5.4 by default"
+  command: update-alternatives --set lua-interpreter /usr/bin/lua5.4
 - name: "Add Prosody package signing key"
   apt_key:
     url: "https://packages.prosody.im/debian/pubkey.asc"
@@ -55,7 +55,7 @@
     name: prosody
     state: stopped
 - name: "Allow Prosody to bind service ports"
-  command: setcap 'cap_net_bind_service=+ep' /usr/bin/lua5.2
+  command: setcap 'cap_net_bind_service=+ep' /usr/bin/lua5.4
 
 - name: Install Mercurial
   apt:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: "Install Lua 5.4"
+- name: "Install Lua 5.2"
   apt:
-    name: lua5.4
+    name: lua5.2
     state: present
     install_recommends: no
-- name: "Use Lua 5.4 by default"
-  command: update-alternatives --set lua-interpreter /usr/bin/lua5.4
+- name: "Use Lua 5.2 by default"
+  command: update-alternatives --set lua-interpreter /usr/bin/lua5.2
 - name: "Add Prosody package signing key"
   apt_key:
     url: "https://packages.prosody.im/debian/pubkey.asc"
@@ -55,7 +55,7 @@
     name: prosody
     state: stopped
 - name: "Allow Prosody to bind service ports"
-  command: setcap 'cap_net_bind_service=+ep' /usr/bin/lua5.4
+  command: setcap 'cap_net_bind_service=+ep' /usr/bin/lua5.2
 
 - name: Install Mercurial
   apt:


### PR DESCRIPTION
#137 broke everything. @horazont identified and corrected serveral problems but there was some sort of performance regression.

After further investigation, the blame was pinned at the extremely aggressive GC settings in https://github.com/snikket-im/snikket-server/commit/e19b0a32afb33df956a1f4ec34d9091a4a48ab8c so this PR reverts that. `threshold = 100` means "start another GC sweep once memory has increased to 100% of what it was at the end of the previous sweep", i.e. at 0% increase in memory use, i.e **all the time**.

@mwild1 suggests reverting to [Prosody's built-in defaults](https://hg.prosody.im/trunk/file/c2616274bef7/util/startup.lua#l17), which is done here via the revert.