### PR TITLE
Extend bootstrap invite TTL

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -160,6 +160,7 @@ invites_page_external = true
 
 invites_bootstrap_index = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_INDEX)
 invites_bootstrap_secret = ENV_TWEAK_SNIKKET_BOOTSTRAP_SECRET
+invites_bootstrap_ttl = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_TTL or (28 * 86400)) -- default 28 days
 
 c2s_require_encryption = true
 s2s_require_encryption = true

--- a/snikket-modules/mod_invites_bootstrap/mod_invites_bootstrap.lua
+++ b/snikket-modules/mod_invites_bootstrap/mod_invites_bootstrap.lua
@@ -5,6 +5,8 @@ local http_formdecode = require "net.http".formdecode;
 local secret = module:get_option_string("invites_bootstrap_secret");
 if not secret then return; end
 
+local bootstrap_invite_ttl = module:get_option_number("invites_bootstrap_ttl");
+
 local invites_bootstrap_store = module:open_store("invites_bootstrap");
 
 -- This should be a non-negative integer higher than any set for the
@@ -37,7 +39,7 @@ local function handle_request(event)
 		roles = { ["prosody:admin"] = true };
 		groups = { "default" };
 		source = "api/token/bootstrap-"..current_index;
-	});
+	}, bootstrap_invite_ttl);
 	if not invite then
 		module:log("error", "Failed to create bootstrap invite! %s", invite_err);
 		return 500;


### PR DESCRIPTION
The default invitation expiry of 7 days has been found to be insufficient - people trying to set up instances sometimes do not redeem their initial invite, then come back and find themselves unable to gain access to the instance.

As a special case, this PR extends the validity of bootstrap invites to 28 days by default (it can be tweaked via an environment variable). From a security perspective, I have an aversion to admin credentials with unlimited lifetimes, and so I don't intend to make them never expire (but we can adjust the value based on deployment experience).

Note that bootstrap invitations are not generally used in self-hosted deployments.

Fixes #167.