### PR TITLE
Remove completed TODO (in Prosody)

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -166,8 +166,6 @@ archive_expires_after = ("%dd"):format(RETENTION_DAYS) -- Remove archived messag
 -- Disable IPv6 by default because Docker does not
 -- have it enabled by default, and s2s to domains
 -- with A+AAAA records breaks (as opposed to just AAAA)
--- TODO: implement happy eyeballs in net.connect
--- https://issues.prosody.im/1246
 use_ipv6 = (ENV_SNIKKET_TWEAK_IPV6 == "1")
 
 log = {


### PR DESCRIPTION
Prosody has [happy eyeballs](https://issues.prosody.im/1246) since some time now and it works pretty well.

Question is whether it is now safe to enable IPv6 by default in Snikket as well?  Does any of this even make sense with host networking?