### PR TITLE
Configure OAuth 2 flows

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -162,6 +162,10 @@ invites_bootstrap_ttl = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_TTL or (28 * 86400)
 allowed_oauth2_grant_types = { "password" }
 allowed_oauth2_response_types = {}
 
+-- Longer access token lifetime than the default
+-- TODO: Use the already longer-lived refresh tokens
+oauth2_access_token_ttl = 86400
+
 c2s_require_encryption = true
 s2s_require_encryption = true
 s2s_secure_auth = true

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -157,6 +157,11 @@ invites_bootstrap_index = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_INDEX)
 invites_bootstrap_secret = ENV_TWEAK_SNIKKET_BOOTSTRAP_SECRET
 invites_bootstrap_ttl = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_TTL or (28 * 86400)) -- default 28 days
 
+-- The Resource Owner Credentials grant used internally between the web portal
+-- and Prosody, so ensure this is enabled. Other unused flows can be disabled.
+allowed_oauth2_grant_types = { "password" }
+allowed_oauth2_response_types = {}
+
 c2s_require_encryption = true
 s2s_require_encryption = true
 s2s_secure_auth = true


### PR DESCRIPTION
Since only the web portal uses the password grant internally, and the password grant is considered insecure, it makes sense to enable it explicitly in case it is disabled by default in mod_http_oauth2 at some point.