### PR TITLE
Update Prosody and modules inc role changes

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -174,7 +174,7 @@ s2s_require_encryption = true
 s2s_secure_auth = true
 
 add_permissions = {
-	["prosody:user"] = {
+	["prosody:registered"] = {
 		"xmpp:federate";
 	};
 }

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -150,6 +150,9 @@ allow_contact_invites = false
 -- Disallow restricted users to create invitations to the server
 deny_user_invites_by_roles = { "prosody:restricted" }
 
+-- This role was renamed 'guest' in Prosody.
+custom_roles = { { name = "prosody:restricted"; priority = 15 } }
+
 invites_page = ENV_SNIKKET_INVITE_URL or ("https://"..DOMAIN.."/invite/{invite.token}/");
 invites_page_external = true
 

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       snapshot: "2023-10-01"
     prosody_modules:
-      revision: "5178c13deb78"
+      revision: "7a4a6ded2bd6"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/supervisor.yml


### PR DESCRIPTION
Updates Prosody and modules to 2023-09-19 snapshots.

Adds the `prosody:restricted` role that was renamed `prosody:guest` as part of [changes to user roles in Prosody](https://hg.prosody.im/trunk/rev/082c7d856e61).

https://github.com/snikket-im/snikket-web-portal/pull/158 is also part of this change.

The module changes herein include one that reduces the lifetime of access tokens, restored by https://github.com/snikket-im/snikket-server/pull/180