### PR TITLE
Do not install packages Recommended by Prosody to reduce image size

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -18,7 +18,7 @@
   apt:
     name: "{{ prosody.package }}"
     state: present
-    install_recommends: yes
+    install_recommends: no
 - name: "Deploy Prosody config"
   copy:
     src: ../files/prosody.cfg.lua


### PR DESCRIPTION
We already install the important packages, namely ca-certificates, lua-readline, lua-unbound but prosody-trunk also recommends luarocks which in turn pulls in Lua 5.1 and Recommends build dependencies such as GCC which inflates the image size.