### PR TITLE
Remove IPv6 tweak, making IPv6 always enabled

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -181,11 +181,6 @@ add_permissions = {
 
 archive_expires_after = ("%dd"):format(RETENTION_DAYS) -- Remove archived messages after N days
 
--- Disable IPv6 by default because Docker does not
--- have it enabled by default, and s2s to domains
--- with A+AAAA records breaks (as opposed to just AAAA)
-use_ipv6 = (ENV_SNIKKET_TWEAK_IPV6 == "1")
-
 log = {
 	[ENV_SNIKKET_LOGLEVEL or "info"] = "*stdout"
 }

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -120,12 +120,6 @@ Just do not set this.
 
 Also better do not set this.
 
-### `SNIKKET_TWEAK_IPV6`
-
-Enable IPv6 support.
-
-By default, IPv6 is disabled because most container runtimes default to it being disabled. Enabling IPv6 in the server could cause issues if the container runtime does not support it.
-
 ### `SNIKKET_TWEAK_PROMETHEUS`
 
 If you are monitoring your Snikket server using [Prometheus](https://prometheus.io/) and scraping the metrics endpoint, you should set this to `1` and let it at its default otherwise.

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -117,14 +117,6 @@ Snikket needs 3 DNS records to be added. Ensure you followed the steps
 from the installation guide correctly, particularly the
 [DNS configuration](https://snikket.org/service/quickstart/#step-1-dns).
 
-If your server supports IPv6, you may also add that to DNS (using an
-AAAA record). If you do this, you *must* tell Snikket by adding the
-following line to your snikket.conf:
-
-```
-SNIKKET_TWEAK_IPV6=1
-```
-
 #### Port 80 blocked
 
 Ensure that port 80 is open and accessible. You can review a [list of


### PR DESCRIPTION
Option 1.

Fixes #56

Mutually exclusive with #184 