### PR TITLE
Enable IPv6 by default, allowing it to be disabled

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -181,10 +181,9 @@ add_permissions = {
 
 archive_expires_after = ("%dd"):format(RETENTION_DAYS) -- Remove archived messages after N days
 
--- Disable IPv6 by default because Docker does not
--- have it enabled by default, and s2s to domains
--- with A+AAAA records breaks (as opposed to just AAAA)
-use_ipv6 = (ENV_SNIKKET_TWEAK_IPV6 == "1")
+-- Allow disabling IPv6 because Docker does not have it enabled by default, but
+-- we don't use Docker networking so it should not matter.
+use_ipv6 = (ENV_SNIKKET_TWEAK_IPV6 ~= "0")
 
 log = {
 	[ENV_SNIKKET_LOGLEVEL or "info"] = "*stdout"

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -122,9 +122,9 @@ Also better do not set this.
 
 ### `SNIKKET_TWEAK_IPV6`
 
-Enable IPv6 support.
+Disable IPv6 support by setting to `0`.
 
-By default, IPv6 is disabled because most container runtimes default to it being disabled. Enabling IPv6 in the server could cause issues if the container runtime does not support it.
+By default, IPv6 is enable because Snikket uses host networking and gracefully handles IPv6 hosts being unreachable.
 
 ### `SNIKKET_TWEAK_PROMETHEUS`
 

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -124,7 +124,7 @@ Also better do not set this.
 
 Disable IPv6 support by setting to `0`.
 
-By default, IPv6 is enable because Snikket uses host networking and gracefully handles IPv6 hosts being unreachable.
+By default, IPv6 is enabled because Snikket uses host networking and gracefully handles IPv6 hosts being unreachable.
 
 ### `SNIKKET_TWEAK_PROMETHEUS`
 

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -118,12 +118,7 @@ from the installation guide correctly, particularly the
 [DNS configuration](https://snikket.org/service/quickstart/#step-1-dns).
 
 If your server supports IPv6, you may also add that to DNS (using an
-AAAA record). If you do this, you *must* tell Snikket by adding the
-following line to your snikket.conf:
-
-```
-SNIKKET_TWEAK_IPV6=1
-```
+AAAA record).
 
 #### Port 80 blocked
 


### PR DESCRIPTION
Option 2

Fixes #56

Mutually exclusive with #183 