### PR TITLE
Tell s6 not to restart coturn when disabled

### DIFF
--- a/ansible/files/services/coturn/finish
+++ b/ansible/files/services/coturn/finish
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+if [ "$SNIKKET_TWEAK_TURNSERVER" = "0" ]; then
+	# tell s6 it's not supposed to be running
+	exit 125
+fi


### PR DESCRIPTION
If `SNIKKET_TWEAK_TURNSERVER=0` then logs are filled with

> f1b92c3120ff TURN server disabled by environment, not launching.
> f1b92c3120ff TURN server disabled by environment, not launching.
> f1b92c3120ff TURN server disabled by environment, not launching.
> f1b92c3120ff TURN server disabled by environment, not launching.

This tells `s6` not to restart coturn after the `run` script fails to start.