### PR TITLE
Update Prosody snapshot

### DIFF
--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,7 +7,7 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      snapshot: "2023-10-01"
+      snapshot: "2023-10-22"
     prosody_modules:
       revision: "7a4a6ded2bd6"
   tasks:


### PR DESCRIPTION
This version includes a change to mod_tokenauth that periodically clears out expired token grants, to stop them from accumulating.

Related: https://github.com/snikket-im/snikket-web-portal/pull/161