### PR TITLE
Use DANE (RFC6698, RFC7673) when DNSSEC is enabled

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -221,6 +221,9 @@ if ENV_SNIKKET_TWEAK_DNSSEC == "1" then
 	assert(require"lunbound".new{ resolvconf = true; trustfile = trustfile }:resolve ".".secure,
 		"Upstream DNS resolver is not DNSSEC-capable. Fix this or disable SNIKKET_TWEAK_DNSSEC");
 	unbound = { trustfile = trustfile }
+
+	-- Since we have DNSSEC, we can also do DANE
+	use_dane = true
 end
 
 certificates = "certs"

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -177,6 +177,7 @@ This nowadays conflicts with the web portal, so you should not set it.
 ### `SNIKKET_TWEAK_DNSSEC`
 
 Enable DNSSEC support. Requires a DNSSEC-capable resolver.
+This also enables DANE for outgoing connections.
 
 ### `SNIKKET_TWEAK_EXTRA_CONFIG`
 


### PR DESCRIPTION
One of the big reasons for having DNSSEC in the first place.

- [x] builds
- [x] runs
- [x] works
- [x] docs