### PR TITLE
Migrate data to SQLite3

### DIFF
--- a/ansible/files/migrator.cfg.lua
+++ b/ansible/files/migrator.cfg.lua
@@ -1,0 +1,62 @@
+local data_path = "/snikket/prosody";
+
+local vhost = {
+	"accounts";
+	"account_details";
+	"account_roles";
+	"roster";
+	"vcard";
+	"private";
+	"blocklist";
+	"privacy";
+	"archive-archive";
+	"offline-archive";
+	"pubsub_nodes-pubsub";
+	"pep-pubsub";
+	"cron";
+	"fast_tokens";
+	"clients";
+	"cloud_notify";
+	"smacks_h";
+	"lastlog2";
+	"invite_token";
+	"invite_api_keys";
+	"invites_tracking";
+	"invites_bootstrap";
+	"update_notifications";
+	"groups";
+	"group_info";
+}
+local muc = {
+	"persistent";
+	"config";
+	"state";
+	"muc_log-archive";
+	"vcard_muc";
+	"cron";
+};
+local upload = {
+	"uploads-archive";
+	"upload_stats";
+	"cron";
+}
+
+local hosts = {
+	-- Real domain subsituted from entrypoint.sh
+	["SNIKKET_DOMAIN"] = vhost;
+	["share.SNIKKET_DOMAIN"] = upload;
+	["groups.SNIKKET_DOMAIN"] = muc;
+}
+
+files {
+	hosts = hosts;
+	type = "internal";
+	path = "/snikket/prosody";
+}
+
+sqlite {
+	hosts = hosts;
+	type = "sql";
+	driver = "SQLite3";
+	database = "/snikket/prosody/prosody.sqlite";
+}

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -206,7 +206,16 @@ authentication = "internal_hashed"
 authorization = "internal"
 disable_sasl_mechanisms = { "PLAIN" }
 
-storage = "internal"
+if ENV_SNIKKET_TWEAK_STORAGE == "sqlite" then
+	storage = "sql"
+	sql = {
+		driver = "SQLite3";
+		database = "/snikket/prosody/prosody.sqlite";
+	}
+else
+	storage = "internal"
+end
+
 statistics = "internal"
 
 if ENV_SNIKKET_TWEAK_PROMETHEUS == "1" then

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -161,3 +161,18 @@
     name: dns-root-data
     state: present
     install_recommends: no
+
+- name: "Install Prosody-Migrator"
+  apt:
+    name: prosody-migrator-trunk
+    state: present
+    install_recommends: no
+- name: "Copy Prosody-Migrator config"
+  copy:
+    src: ../files/migrator.cfg.lua
+    dest: /etc/prosody/migrator.cfg.lua
+- name: "Install LuaDBI driver for SQLite3"
+  apt:
+    name: lua-dbi-sqlite3
+    state: present
+    install_recommends: no

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -195,3 +195,7 @@ This also enables DANE for outgoing connections.
 ### `SNIKKET_TWEAK_EXTRA_CONFIG`
 
 Path or glob for extra configuration files to load.
+
+### `SNIKKET_TWEAK_STORAGE`
+
+Sneak preview of SQLite storage. Valid values are `files` (the default) and `sqlite` (potential future default).


### PR DESCRIPTION
Switches to SQLite3 via LuaDBI for storage, including migration.

- [x] builds
- [x] runs
- [x] works
  - [x] user data migrated
  - [x] prosody runs fine
  - [x] tested with uploaded files
  - [x] tested reverting to `files`
- [x] tweakable
  - [x] documented

Fixes #47