### PR TITLE
Bump prosody-modules for multi-MUC circles

### DIFF
--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       snapshot: "2023-10-22"
     prosody_modules:
-      revision: "7a4a6ded2bd6"
+      revision: "78f766372e2c"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/services.yml


### PR DESCRIPTION
Fixes #149 

Circles now come with no MUC by default. One or more MUCs can be created for a circle via the web portal (https://github.com/snikket-im/snikket-web-portal/pull/165).

This introduces data format changes which would break on downgrade for circles that have been edited to use this feature.