### PR TITLE
Prosody config updates Dec 2023

### DIFF
--- a/ansible/files/patches/prosody/modules/prosody-6877786d73d7.patch
+++ b/ansible/files/patches/prosody/modules/prosody-6877786d73d7.patch
@@ -1,0 +1,18 @@
+# HG changeset patch
+# User Matthew Wild <mwild1@gmail.com>
+# Date 1702388474 0
+# Node ID 6877786d73d7e2b7f6cd6345560d03e0b6826fdf
+# Parent  626ab0af83af942d0da824a3926b55ca5e418275
+mod_storage_internal, tests: Fix before/after combined with the 'reverse' flag
+
+diff -r 626ab0af83af -r 6877786d73d7 plugins/mod_storage_internal.lua
+--- a/mod_storage_internal.lua	Sat Dec 09 21:01:49 2023 +0100
++++ b/mod_storage_internal.lua	Tue Dec 12 13:41:14 2023 +0000
+@@ -180,6 +180,7 @@
+ 				i = i - 1
+ 				return list[i]
+ 			end
++			query.before, query.after = query.after, query.before;
+ 		end
+ 		if query.key then
+ 			iter = it.filter(function(item)

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -205,6 +205,10 @@ add_permissions = {
 
 archive_expires_after = ("%dd"):format(RETENTION_DAYS) -- Remove archived messages after N days
 
+-- Delay full account deletion via IBR for RETENTION_DAYS, to allow restoration
+-- in case of accidental or malicious deletion of an account
+registration_delete_grace_period = ("%d days"):format(RETENTION_DAYS)
+
 -- Allow disabling IPv6 because Docker does not have it enabled by default, but
 -- we don't use Docker networking so it should not matter.
 use_ipv6 = (ENV_SNIKKET_TWEAK_IPV6 ~= "0")

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -307,6 +307,12 @@ VirtualHost (DOMAIN)
 		}
 	end
 
+	if ENV_SNIKKET_TWEAK_S2S_STATUS == "1" then
+		modules_enabled: append {
+			"s2s_status";
+		}
+	end
+
 Component ("groups."..DOMAIN) "muc"
 	modules_enabled = {
 		"muc_mam";
@@ -318,6 +324,13 @@ Component ("groups."..DOMAIN) "muc"
 		"snikket_deprecate_general_muc";
 		"muc_auto_reserve_nicks";
 	}
+
+	if ENV_SNIKKET_TWEAK_S2S_STATUS == "1" then
+		modules_enabled: append {
+			"s2s_status";
+		}
+	end
+
 	restrict_room_creation = "local"
 
 	-- Some older deployments may have the general@ MUC, so we still need

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -163,6 +163,13 @@ password_policy = {
 	length = 10;
 }
 
+-- In the future we want to switch to SASL2 for better security,
+-- as client ids are not supported in SASL1 (identification is via
+-- the resource string, which is semi-public and not authenticated)
+-- This tweak is for developers to test with the future configuration,
+-- or people who want to opt into the new security sooner.
+enforce_client_ids = ENV_SNIKKET_TWEAK_REQUIRE_SASL2 == "1"
+
 -- This disables in-app invites for non-admins
 -- TODO: The plan is to enable it once we can
 -- give the admin more fine-grained control

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -1,9 +1,9 @@
-local DOMAIN = assert(ENV_SNIKKET_DOMAIN, "Please set the SNIKKET_DOMAIN environment variable")
+local DOMAIN = Lua.assert(ENV_SNIKKET_DOMAIN, "Please set the SNIKKET_DOMAIN environment variable")
 
-local RETENTION_DAYS = tonumber(ENV_SNIKKET_RETENTION_DAYS) or 7;
-local UPLOAD_STORAGE_GB = tonumber(ENV_SNIKKET_UPLOAD_STORAGE_GB);
+local RETENTION_DAYS = Lua.tonumber(ENV_SNIKKET_RETENTION_DAYS) or 7;
+local UPLOAD_STORAGE_GB = Lua.tonumber(ENV_SNIKKET_UPLOAD_STORAGE_GB);
 
-if prosody.process_type == "prosody" and not prosody.config_loaded then
+if Lua.prosody.process_type == "prosody" and not Lua.prosody.config_loaded then
 	-- Wait at startup for certificates
 	local lfs, socket = require "lfs", require "socket";
 	local cert_path = "/etc/prosody/certs/"..DOMAIN..".crt";
@@ -11,10 +11,10 @@ if prosody.process_type == "prosody" and not prosody.config_loaded then
 	while not lfs.attributes(cert_path, "mode") do
 		counter = counter + 1;
 		if counter == 1 or counter%6 == 0 then
-			print("Waiting for certificates...");
+			Lua.print("Waiting for certificates...");
 		elseif counter > 60 then
-			print("No certificates found... exiting");
-			os.exit(1);
+			Lua.print("No certificates found... exiting");
+			Lua.os.exit(1);
 		end
 		socket.sleep(5);
 	end
@@ -185,9 +185,9 @@ custom_roles = { { name = "prosody:restricted"; priority = 15 } }
 invites_page = ENV_SNIKKET_INVITE_URL or ("https://"..DOMAIN.."/invite/{invite.token}/");
 invites_page_external = true
 
-invites_bootstrap_index = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_INDEX)
+invites_bootstrap_index = Lua.tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_INDEX)
 invites_bootstrap_secret = ENV_TWEAK_SNIKKET_BOOTSTRAP_SECRET
-invites_bootstrap_ttl = tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_TTL or (28 * 86400)) -- default 28 days
+invites_bootstrap_ttl = Lua.tonumber(ENV_TWEAK_SNIKKET_BOOTSTRAP_TTL or (28 * 86400)) -- default 28 days
 
 -- The Resource Owner Credentials grant used internally between the web portal
 -- and Prosody, so ensure this is enabled. Other unused flows can be disabled.
@@ -255,7 +255,7 @@ end
 if ENV_SNIKKET_TWEAK_DNSSEC == "1" then
 	local trustfile = "/usr/share/dns/root.ds"; -- Requires apt:dns-root-data
 	-- Bail out if it doesn't work
-	assert(require"lunbound".new{ resolvconf = true; trustfile = trustfile }:resolve ".".secure,
+	Lua.assert(require"lunbound".new{ resolvconf = true; trustfile = trustfile }:resolve ".".secure,
 		"Upstream DNS resolver is not DNSSEC-capable. Fix this or disable SNIKKET_TWEAK_DNSSEC");
 	unbound = { trustfile = trustfile }
 
@@ -284,7 +284,7 @@ http_external_url = "https://"..DOMAIN.."/"
 
 if ENV_SNIKKET_TWEAK_TURNSERVER ~= "0" or ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN then
 	turn_external_host = ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN or DOMAIN
-	turn_external_secret = ENV_SNIKKET_TWEAK_TURNSERVER_SECRET or assert(io.open("/snikket/prosody/turn-auth-secret-v2")):read("*l");
+	turn_external_secret = ENV_SNIKKET_TWEAK_TURNSERVER_SECRET or Lua.assert(Lua.io.open("/snikket/prosody/turn-auth-secret-v2")):read("*l");
 end
 
 -- Allow restricted users access to push notification servers

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -63,6 +63,12 @@ modules_enabled = {
 		"sasl2_fast";
 		"client_management";
 
+	-- Event auditing
+		"audit";
+		"audit_auth"; -- Audit authentication attempts and new clients
+		"audit_status"; -- Audit status changes of the server (start, stop, crash)
+		"audit_user_accounts"; -- Audit status changes of user accounts (created, deleted, etc.)
+
 	-- Push notifications
 		"cloud_notify";
 		"cloud_notify_extensions";

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -91,7 +91,6 @@ modules_enabled = {
 		"update_notify";
 		"turn_external";
 		"admin_shell";
-		"isolate_host";
 		"snikket_client_id";
 		"snikket_ios_preserve_push";
 		"snikket_restricted_users";
@@ -293,6 +292,9 @@ isolate_except_domains = { "push.snikket.net", "push-ios.snikket.net" }
 VirtualHost (DOMAIN)
 	authentication = "internal_hashed"
 
+	modules_enabled = {}
+	firewall_scripts = {}
+
 	http_files_dir = "/var/www"
 	http_paths = {
 		files = "/";
@@ -310,6 +312,16 @@ VirtualHost (DOMAIN)
 	if ENV_SNIKKET_TWEAK_S2S_STATUS == "1" then
 		modules_enabled: append {
 			"s2s_status";
+		}
+	end
+
+	if ENV_SNIKKET_TWEAK_RESTRICTED_USERS_V2 == "1" then
+		firewall_scripts: append {
+			"/etc/prosody/firewall/restricted_users.pfw";
+		}
+	else
+		modules_enabled: append {
+			"isolate_host";
 		}
 	end
 

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -302,7 +302,7 @@ VirtualHost (DOMAIN)
 	}
 
 	if ENV_SNIKKET_TWEAK_PROMETHEUS == "1" then
-		modules_enabled = {
+		modules_enabled: append {
 			"http_openmetrics";
 		}
 	end

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -45,6 +45,7 @@ modules_enabled = {
 		"blocklist"; -- Allow users to block communications with other users
 		"vcard4"; -- User profiles (stored in PEP)
 		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
+		"password_policy";
 
 	-- Nice to have
 		"version"; -- Replies to server version requests
@@ -151,6 +152,10 @@ c2s_direct_tls_ports = { 5223 }
 
 allow_registration = true
 registration_invite_only = true
+
+password_policy = {
+	length = 10;
+}
 
 -- This disables in-app invites for non-admins
 -- TODO: The plan is to enable it once we can

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -357,4 +357,8 @@ Component ("share."..DOMAIN) "http_file_share"
 		file_share = "/upload"
 	}
 
+	modules_disabled = {
+		"s2s";
+	}
+
 Include (ENV_SNIKKET_TWEAK_EXTRA_CONFIG or "/snikket/prosody/*.cfg.lua")

--- a/ansible/files/restricted_users.pfw
+++ b/ansible/files/restricted_users.pfw
@@ -1,0 +1,14 @@
+::deliver
+
+ENTERING: $local
+TO ROLE: prosody:restricted
+NOT SUBSCRIBED?
+BOUNCE=policy-violation (Recipient does not accept messages from strangers)
+
+::preroute
+
+LEAVING: $local
+FROM ROLE: prosody:restricted
+NOT SUBSCRIBED?
+BOUNCE=policy-violation (Your account is not permitted to communicate with strangers)
+

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,9 +7,9 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      snapshot: "2023-12-01"
+      snapshot: "2023-12-11"
     prosody_modules:
-      revision: "238c4ac8b735"
+      revision: "9d3d719db285"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/services.yml

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       snapshot: "2023-12-11"
     prosody_modules:
-      revision: "9d3d719db285"
+      revision: "14e17927c0ec"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/services.yml

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -192,3 +192,11 @@
     name: lua-dbi-sqlite3
     state: present
     install_recommends: no
+
+- name: "Apply Prosody module patches"
+  patch:
+    src: "{{item}}"
+    basedir: "/usr/lib/prosody/modules"
+    strip: 1
+  with_fileglob:
+    - "../files/patches/prosody/modules/*.patch"

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -122,6 +122,10 @@
     - mod_sasl2_sm
     - mod_sasl2_fast
     - mod_client_management
+    - mod_audit
+    - mod_audit_auth
+    - mod_audit_status
+    - mod_audit_user_accounts
     - mod_password_policy
 
 - name: Enable wanted modules (snikket-modules)

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -127,6 +127,7 @@
     - mod_audit_status
     - mod_audit_user_accounts
     - mod_password_policy
+    - mod_s2s_status
 
 - name: Enable wanted modules (snikket-modules)
   file:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -122,6 +122,7 @@
     - mod_sasl2_sm
     - mod_sasl2_fast
     - mod_client_management
+    - mod_password_policy
 
 - name: Enable wanted modules (snikket-modules)
   file:

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -34,6 +34,10 @@
   file:
     state: directory
     path: /etc/prosody/modules
+- name: "Create Prosody firewall directory"
+  file:
+    state: directory
+    path: /etc/prosody/firewall
 - name: "Create web root directory"
   file:
     state: directory
@@ -143,6 +147,12 @@
     - mod_snikket_ios_preserve_push
     - mod_snikket_restricted_users
     - mod_snikket_deprecate_general_muc
+
+- name: "Install mod_firewall rules"
+  copy:
+    src: ../files/restricted_users.pfw
+    dest: /etc/prosody/firewall/
+    mode: 0644
 
 - name: "Install lua-ossl for encrypted push notifications"
   apt:

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -235,7 +235,7 @@ Path or glob for extra configuration files to load.
 
 Sneak preview of SQLite storage. Valid values are `files` (the default) and `sqlite` (potential future default).
 
-### `ENV_SNIKKET_TWEAK_REQUIRE_SASL2`
+### `SNIKKET_TWEAK_REQUIRE_SASL2`
 
 When set to `1` this will disable support for legacy SASL, requiring all
 clients to support SASL2. We plan for this to be the default in the future due
@@ -245,3 +245,15 @@ apps without SASL2 support and this would prevent them connecting.
 The tweak is available now so developers can ensure their client will work in
 SASL2-only mode, or admins can disable legacy SASL early if they are certain
 of only using SASL2-capable clients.
+
+### `SNIKKET_TWEAK_RESTRICTED_USERS_V2`
+
+When set to `1` this will enable an alternative implementation of "restricted
+users". It is primarily for testing the implementation that is expected to
+become the default in a future release.
+
+### `SNIKKET_TWEAK_S2S_STATUS`
+
+When set to `1` this will enable a module that monitors the list and health of
+server-to-server connections. This is only useful for developers, as the
+information cannot currently be viewed in the user interface.

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -130,6 +130,41 @@ The TCP port on which the internal HTTP API listens on. The default is `5280`. D
 
 The IP address on which the internal HTTP API listens on. The default is `127.0.0.1`, so that the API is only accessible from the same server. Changing this may be a security risk as some general system information is accessible without authentication.
 
+### `SNIKKET_TWEAK_HTTP_TLS_VERSIONS`
+
+The TLS versions to offer for HTTPS. Changing this may make your setup less
+secure, or else prevent some browsers or operating systems from connecting to
+your instance.
+
+By default we follow Mozilla's TLS 'intermediate' profile, which balances
+strong security with allowing a range of browsers and clients to connect.
+
+To follow Mozilla's 'strict' profile (which may cause connectivity issues with
+Android < 9, Windows < 11, Safari/iOS < 12, and others), set:
+
+```
+SNIKKET_TWEAK_HTTP_TLS_VERSIONS=TLSv1.3
+SNIKKET_TWEAK_HTTP_TLS_CIPHERS=
+```
+
+### `SNIKKET_TWEAK_HTTP_TLS_CIPHERS`
+
+The TLS ciphers to offer for HTTPS. See the previous option about TLS version
+configuration for more details.
+
+### `SNIKKET_TWEAK_WEB_PROXY_PROTOCOLS`
+
+This is for customization of the web proxy configuration. After adding new
+configuration templates, this can be used to load them, it's a list of
+space-separated names.
+
+Defaults to `http https`.
+
+### `SNIKKET_TWEAK_WEB_PROXY_RELOAD_INTERVAL`
+
+The number of seconds between reloads of the web proxy (i.e. to pick up new
+certificates). Specified as a number of seconds, or `inf` to disable reloads.
+
 ### `SNIKKET_INVITE_URL`
 
 The URL template for invitation links. The server needs to know under which address the invitation service is hosted.

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -199,3 +199,14 @@ Path or glob for extra configuration files to load.
 ### `SNIKKET_TWEAK_STORAGE`
 
 Sneak preview of SQLite storage. Valid values are `files` (the default) and `sqlite` (potential future default).
+
+### `ENV_SNIKKET_TWEAK_REQUIRE_SASL2`
+
+When set to `1` this will disable support for legacy SASL, requiring all
+clients to support SASL2. We plan for this to be the default in the future due
+to increased security, speed and other features, but currently there are many
+apps without SASL2 support and this would prevent them connecting.
+
+The tweak is available now so developers can ensure their client will work in
+SASL2-only mode, or admins can disable legacy SASL early if they are certain
+of only using SASL2-capable clients.


### PR DESCRIPTION
This PR brings a bunch of updates for Prosody:

- Password policy enforcement
- Audit logging
- Soft deletion via IBR
- Ability to allow SASL2 auth only
- Remove s2s from share subdomain
- Refactor config using new syntax supported in Prosody
- New restricted user isolation via mod_firewall (preview)