### PR TITLE
Disable SASL OAUTHBEARER

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -225,7 +225,7 @@ log = {
 
 authentication = "internal_hashed"
 authorization = "internal"
-disable_sasl_mechanisms = { "PLAIN" }
+disable_sasl_mechanisms = { "PLAIN", "OAUTHBEARER" }
 
 if ENV_SNIKKET_TWEAK_STORAGE == "sqlite" then
 	storage = "sql"


### PR DESCRIPTION
OAuth 2 is not meant to be a current Snikket feature and is only used internally. SASL OAUTHBEARER will not work without the certain https endpoints exposed anyway.

Related to https://github.com/snikket-im/snikket-web-proxy/pull/22