### PR TITLE
Enable mod_sasl_ssdp from community modules for XEP-0474 support

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -62,6 +62,7 @@ modules_enabled = {
 		"sasl2_sm";
 		"sasl2_fast";
 		"client_management";
+		"sasl_ssdp";
 
 	-- Event auditing
 		"audit";

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -132,6 +132,7 @@
     - mod_audit_user_accounts
     - mod_password_policy
     - mod_s2s_status
+    - mod_sasl_ssdp
 
 - name: Enable wanted modules (snikket-modules)
   file:


### PR DESCRIPTION
This is an experimental XEP, not currently used by the Snikket apps. However it is pretty harmless and we'd like to get more implementation experience. This seems like a good opportunity do to that.