### PR TITLE
snikket-modules: Update imports for Prosody namespace change

### DIFF
--- a/snikket-modules/mod_invites_bootstrap/mod_invites_bootstrap.lua
+++ b/snikket-modules/mod_invites_bootstrap/mod_invites_bootstrap.lua
@@ -1,6 +1,6 @@
 --luacheck: ignore 143/module
 
-local http_formdecode = require "net.http".formdecode;
+local http_formdecode = require "prosody.net.http".formdecode;
 
 local secret = module:get_option_string("invites_bootstrap_secret");
 if not secret then return; end

--- a/snikket-modules/mod_snikket_billing/mod_snikket_billing.lua
+++ b/snikket-modules/mod_snikket_billing/mod_snikket_billing.lua
@@ -1,8 +1,8 @@
-local dt = require "util.datetime";
-local http = require "net.http";
-local json = require "util.json";
-local promise = require "util.promise";
-local st = require "util.stanza";
+local dt = require "prosody.util.datetime";
+local http = require "prosody.net.http";
+local json = require "prosody.util.json";
+local promise = require "prosody.util.promise";
+local st = require "prosody.util.stanza";
 
 local billing_api = module:get_option_string("snikket_billing_api");
 local billing_dashboard_url = module:get_option_string("snikket_billing_dashboard");
@@ -75,8 +75,8 @@ end);
 
 -- Allow restricting federation for trial instances, to prevent their use for spam and abuse
 do
-	local is_user_subscribed = require "core.rostermanager".is_user_subscribed;
-	local jid_host = require "util.jid".host;
+	local is_user_subscribed = require "prosody.core.rostermanager".is_user_subscribed;
+	local jid_host = require "prosody.util.jid".host;
 	module:hook("route/remote", function (event)
 		if features.federation ~= "restricted" then return; end
 		local origin, stanza = event.origin, event.stanza;

--- a/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
+++ b/snikket-modules/mod_snikket_restricted_users/mod_snikket_restricted_users.lua
@@ -1,4 +1,4 @@
-local um_get_jid_role = require "core.usermanager".get_jid_role;
+local um_get_jid_role = require "prosody.core.usermanager".get_jid_role;
 
 local function load_groups_host(module)
 	local primary_host = module.host:gsub("^%a+%.", "");

--- a/snikket-modules/mod_update_check/mod_update_check.lua
+++ b/snikket-modules/mod_update_check/mod_update_check.lua
@@ -1,10 +1,10 @@
-local adns = require "net.adns";
+local adns = require "prosody.net.adns";
 local r = adns.resolver();
 
 local function dns_escape(input)
 	return (input:gsub("%W", "_"));
 end
-local render_hostname = require "util.interpolation".new("%b{}", dns_escape);
+local render_hostname = require "prosody.util.interpolation".new("%b{}", dns_escape);
 
 local update_dns = module:get_option_string("update_check_dns");
 local check_interval = module:get_option_number("update_check_interval", 86400);

--- a/snikket-modules/mod_update_notify/mod_update_notify.lua
+++ b/snikket-modules/mod_update_notify/mod_update_notify.lua
@@ -1,5 +1,5 @@
-local urlencode = require "util.http".urlencode;
-local interpolation = require "util.interpolation";
+local urlencode = require "prosody.util.http".urlencode;
+local interpolation = require "prosody.util.interpolation";
 
 local render_url = interpolation.new("%b{}", urlencode);
 local render_text = interpolation.new("%b{}", function (s) return s; end);


### PR DESCRIPTION
Removes reliance on import name compatibility (`loader.lua` in Prosody)

Ref https://issues.prosody.im/1223