### PR TITLE
mod_snikket_version

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -56,7 +56,7 @@ modules_enabled = {
 		"password_policy";
 
 	-- Nice to have
-		"version"; -- Replies to server version requests
+		"snikket_version"; -- Replies to server version requests
 		"uptime"; -- Report how long server has been running
 		"time"; -- Let others know the time here on this server
 		"ping"; -- Replies to XMPP pings with pongs

--- a/snikket-modules/mod_snikket_version/mod_snikket_version.lua
+++ b/snikket-modules/mod_snikket_version/mod_snikket_version.lua
@@ -1,0 +1,13 @@
+
+local st = require "prosody.util.stanza";
+
+module:add_feature("jabber:iq:version");
+local query = st.stanza("query", {xmlns = "jabber:iq:version"})
+	:text_tag("name", "Snikket")
+	:text_tag("version", "");
+
+module:hook("iq-get/host/jabber:iq:version:query", function(event)
+	local origin, stanza = event.origin, event.stanza;
+	origin.send(st.reply(stanza):add_child(query));
+	return true;
+end);


### PR DESCRIPTION
Replacement for the use of Prosody's mod_version and overriding of the internal `prosody.version` variable, which complicates finding out the actual Prosody version in use.