### PR TITLE
Update docs for compose v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ then put the new one in its place. For example:
 ```
 mv docker-compose.yml docker-compose.old.yml
 wget -O docker-compose.yml https://snikket.org/service/resources/docker-compose.beta.yml
-docker-compose pull
-docker-compose up -d --remove-orphans
+docker compose pull
+docker compose up -d --remove-orphans
 ```
 
 You may also want to check out our new repository of scripts to help

--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ The easiest way is to use docker-compose. Copy the file `snikket.conf.example` t
 `snikket.conf` and edit the values in it. Then run:
 
 ```console
-docker-compose up -d
+docker compose up -d
 ```

--- a/docs/advanced/config.md
+++ b/docs/advanced/config.md
@@ -19,7 +19,7 @@ In most situations, the configuration options shown in the example config in
 Also, it is very likely not complete.
 {{< /panel >}}
 
-After modifying any options in snikket.conf, you must run 'docker-compose up -d' to apply the changes.
+After modifying any options in snikket.conf, you must run 'docker compose up -d' to apply the changes.
 
 ## Configuration Option Reference
 

--- a/docs/setup/troubleshooting.md
+++ b/docs/setup/troubleshooting.md
@@ -109,7 +109,7 @@ There are two options to fix this:
 
    ```
    systemctl restart docker
-   docker-compose up -d  # <- run this in your snikket directory
+   docker compose up -d  # <- run this in your snikket directory
    ```
 
 ## Certificate problems
@@ -176,7 +176,7 @@ problem could be, check the error log:
 
 ```
 cd /etc/snikket
-docker-compose exec snikket_certs cat /var/log/letsencrypt/errors.log
+docker compose exec snikket_certs cat /var/log/letsencrypt/errors.log
 ```
 
 If you get a "No such file or directory" error when running the above command,
@@ -184,7 +184,7 @@ inspect the debug log instead:
 
 ```
 cd /etc/snikket
-docker-compose exec snikket_certs cat /var/log/letsencrypt/letsencrypt.log | grep detail
+docker compose exec snikket_certs cat /var/log/letsencrypt/letsencrypt.log | grep detail
 ```
 
 #### Trying again
@@ -194,7 +194,7 @@ following command:
 
 ```
 cd /etc/snikket
-docker-compose exec snikket_certs /etc/cron.daily/certbot
+docker compose exec snikket_certs /etc/cron.daily/certbot
 ```
 
 If that command says that no certificates are due for renewal, but you need to
@@ -202,7 +202,7 @@ trigger a renewal anyway, run:
 
 ```
 cd /etc/snikket
-docker-compose exec snikket_certs su letsencrypt -- -c "certbot renew --config-dir /snikket/letsencrypt --cert-path /etc/ssl/certbot --force-renew"
+docker compose exec snikket_certs su letsencrypt -- -c "certbot renew --config-dir /snikket/letsencrypt --cert-path /etc/ssl/certbot --force-renew"
 ```
 
 Note that Let's Encrypt has strict [rate limits](https://letsencrypt.org/docs/rate-limits/) -

--- a/docs/setup/upgrading.md
+++ b/docs/setup/upgrading.md
@@ -35,8 +35,8 @@ on the website (most likely), then use these commands:
 
 ```
     cd /etc/snikket
-    docker-compose pull
-    docker-compose up -d
+    docker compose pull
+    docker compose up -d
 ```
 
 ### snikket-selfhosted


### PR DESCRIPTION
Seems people have a recent enough Docker to have the [new command](https://docs.docker.com/compose/migrate/) but are missing the old, which causes confusion.
