### PR TITLE
Manage publishing of Snikket version from new module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/*
 
-RUN echo "Snikket $BUILD_SERIES $BUILD_ID" > /usr/lib/prosody/prosody.version
+RUN echo "Snikket $BUILD_SERIES $BUILD_ID" > /usr/lib/prosody/snikket.version
 
 VOLUME ["/snikket"]

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -56,7 +56,6 @@ modules_enabled = {
 		"password_policy";
 
 	-- Nice to have
-		"version"; -- Replies to server version requests
 		"uptime"; -- Report how long server has been running
 		"time"; -- Let others know the time here on this server
 		"ping"; -- Replies to XMPP pings with pongs
@@ -105,6 +104,7 @@ modules_enabled = {
 		"lastlog2";
 		"admin_blocklist";
 		"snikket_server_vcard";
+		"snikket_version"; -- Replies to server version requests
 
 	-- Spam/abuse management
 		"spam_reporting"; -- Allow users to report spam/abuse

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -156,6 +156,7 @@
     - mod_health_report
     - mod_snikket_server_vcard
     - mod_snikket_billing
+    - mod_snikket_version
 
 - name: "Install mod_firewall rules"
   copy:

--- a/snikket-modules/mod_health_report/mod_health_report.lua
+++ b/snikket-modules/mod_health_report/mod_health_report.lua
@@ -15,6 +15,7 @@ local metric_registry = require "core.statsmanager".get_metric_registry();
 
 local mod_audit_status = module:depends("audit_status");
 local mod_measure_active_users = module:depends("measure_active_users");
+local mod_snikket_version = module:depends("snikket_version");
 
 local last_health_report;
 
@@ -43,7 +44,7 @@ function report_health()
 		dau = get_gauge_metric("prosody_mod_measure_active_users/active_users_1d");
 		wau = get_gauge_metric("prosody_mod_measure_active_users/active_users_7d");
 		mau = get_gauge_metric("prosody_mod_measure_active_users/active_users_30d");
-		version = prosody.version;
+		version = mod_snikket_version.snikket_version;
 	};
 
 	if not has_changed(health, last_health_report) then

--- a/snikket-modules/mod_snikket_version/mod_snikket_version.lua
+++ b/snikket-modules/mod_snikket_version/mod_snikket_version.lua
@@ -1,0 +1,25 @@
+
+local st = require "prosody.util.stanza";
+local paths = require "prosody.util.paths";
+snikket_version = "";
+
+function module.load()
+	local version_filename = paths.join(prosody.paths.source, "snikket.version");
+	local version_fh, err = io.open(version_filename);
+	if not version_fh then
+		module:log("error", "Could not discover Snikket version: %s", err);
+		return
+	end
+	snikket_version = version_fh:read();
+	version_fh:close();
+end
+
+module:add_feature("jabber:iq:version");
+module:hook("iq-get/host/jabber:iq:version:query", function(event)
+	local origin, stanza = event.origin, event.stanza;
+
+	origin.send(st.reply(stanza):query("jabber:iq:version")
+			:text_tag("name", "Snikket")
+			:text_tag("version", snikket_version));
+	return true;
+end);

--- a/snikket-modules/mod_update_check/mod_update_check.lua
+++ b/snikket-modules/mod_update_check/mod_update_check.lua
@@ -9,10 +9,12 @@ local render_hostname = require "prosody.util.interpolation".new("%b{}", dns_esc
 local update_dns = module:get_option_string("update_check_dns");
 local check_interval = module:get_option_number("update_check_interval", 86400);
 
+local mod_snikket_version = module:depends("snikket_version");
+
 local version_info = {};
 
 do
-	local version_string = prosody.version;
+	local version_string = mod_snikket_version.snikket_version;
 	-- "dev 128-00000", "release v2021.05r2", "release beta.20220119"
 	local series, version = version_string:match("(%w+) (%S+)$");
 	if series then


### PR DESCRIPTION
## Summary

This replaces Prosodys `mod_version` with a new `mod_snikket_version`
that retrieves the Snikket version, now stored in a different file, and
advertises it via [XEP-0092](https://xmpp.org/extensions/xep-0092.html).

This also makes Snikket identify itself as `Snikket version stable.yyyymmdd`
instead of `Prosody version Snikket stable.yyyymmdd`.

## Why

Overwriting `prosody.version` as done in the `Dockerfile` previously
makes it difficult to determine the Prosody version, which is useful to
know while investigating or debugging issues.

## How

By storing the Snikket version in a different file and reading it once
from this new module, the Prosody version can still be discovered via
`prosodyctl about` and similar.

The version is also made available to some other modules that rely on
the Snikket version, without those modules needing to know how to
retrieve the version.

## Related

- [ ] The snikket-web-portal still reports the Snikket version as the Prosody version.

## Status

- [x] Builds
- [x] Runs
- [x] Works
