### PR TITLE
Simplify config with new read-from-file feature

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -302,7 +302,7 @@ http_external_url = "https://"..DOMAIN.."/"
 if ENV_SNIKKET_TWEAK_TURNSERVER ~= "0" or ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN then
 	turn_external_host = ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN or DOMAIN
 	turn_external_port = ENV_SNIKKET_TWEAK_TURNSERVER_PORT
-	turn_external_secret = ENV_SNIKKET_TWEAK_TURNSERVER_SECRET or Lua.assert(Lua.io.open("/snikket/prosody/turn-auth-secret-v2")):read("*l");
+	turn_external_secret = ENV_SNIKKET_TWEAK_TURNSERVER_SECRET or FileLine("/snikket/prosody/turn-auth-secret-v2")
 	turn_external_tcp = true
 end
 

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -7,7 +7,7 @@
   vars:
     prosody:
       package: "prosody-trunk"
-      snapshot: "2025-01-07"
+      snapshot: "2025-01-17"
     prosody_modules:
       revision: "c42419d73737"
   tasks:


### PR DESCRIPTION
Uses new feature added in https://hg.prosody.im/trunk/rev/ac60c21015c7
to simplify retrieving the turnserver secret, avoiding one direct usage
of the Lua stdlib

## Status

- [x] Builds
- [x] Runs
- [x] Works
