### PR TITLE
Some webpush (such as safari) requires a URL

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -336,6 +336,7 @@ VirtualHost (DOMAIN)
 	end
 
 	if ENV_SNIKKET_TWEAK_PUSH2 == "1" then
+		contact_uri = "https://" .. DOMAIN .. "/"
 		modules_enabled: append {
 			"push2";
 		}


### PR DESCRIPTION
Mozilla isn't picky and will take our xmpp URI default, but Safari really wants "a URL or mailto:"

https://developer.apple.com/documentation/usernotifications/sending-web-push-notifications-in-web-apps-and-browsers