### PR TITLE
Delete localhost cert created by package postinst script

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -50,6 +50,13 @@
     group: adm
     mode: 0750
     recurse: yes
+- name: "Delete localhost cert created by package postinst script"
+  file:
+    path: "/etc/prosody/certs/{{ item }}"
+    state: absent
+  loop:
+    - localhost.crt
+    - localhost.key
 - name: "Disable Prosody init script"
   service:
     name: prosody


### PR DESCRIPTION
After installing the `prosody-trunk` package, the
[`postinst`](https://hg.prosody.im/debian-trunk/file/97a741185e4f/prosody-trunk.postinst)
script generates a certificate and corresponding private key for
`localhost`. For regular installs this might be useful to ensure that at
least one certificate exists to populate Prosodys certificate discovery
mechanism, possibly to serve as a default certificate when no other
hostname included in the TLS SNI extension. Since the container image is
built once, these get distributed along with it, which is not desirable.

Noticed by a user in July 2024
