### PR TITLE
Drop lua-luaossl since mod_cloud_notify_encrypted no longer needs it

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -170,12 +170,6 @@
     dest: /etc/prosody/firewall/
     mode: 0644
 
-- name: "Install lua-ossl for encrypted push notifications"
-  apt:
-    name: lua-luaossl
-    state: present
-    install_recommends: no
-
 - name: "Install luaunbound"
   apt:
     name: lua-unbound


### PR DESCRIPTION
mod_cloud_notify_encrypted no longer needs lua-luaossl, so this PR
removes it from the Ansible stack
