### PR TITLE
Update prosody-modules snapshot for mod_http_oauth2 improvements

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -206,7 +206,7 @@ groups_muc_host = "groups."..DOMAIN
 -- The Resource Owner Credentials grant used internally between the web portal
 -- and Prosody, so ensure this is enabled. Other unused flows can be disabled.
 allowed_oauth2_grant_types = { "password" }
-allowed_oauth2_response_types = {"code"}
+allowed_oauth2_response_types = {}
 
 -- Longer access token lifetime than the default
 -- TODO: Use the already longer-lived refresh tokens

--- a/ansible/snikket.yml
+++ b/ansible/snikket.yml
@@ -9,7 +9,7 @@
       package: "prosody-trunk"
       snapshot: "2025-06-02"
     prosody_modules:
-      revision: "4b52d579bc70"
+      revision: "b7eb7d256939"
   tasks:
     - import_tasks: tasks/prosody.yml
     - import_tasks: tasks/services.yml


### PR DESCRIPTION
No longer required to include the "code" response type when registering
a password-grant-only client.

To go with https://github.com/snikket-im/snikket-web-portal/pull/202

