### PR TITLE
Remove conflicting community modules

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -360,7 +360,6 @@ Component ("groups."..DOMAIN) "muc"
 		"muc_mam";
 		"muc_moderation";
 		"muc_local_only";
-		"vcard_muc";
 		"muc_defaults";
 		"muc_offline_delivery";
 		"snikket_restricted_users";

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -87,7 +87,6 @@
     src: "/usr/local/lib/prosody-modules/{{item}}"
     dest: "/etc/prosody/modules/{{item}}"
   loop:
-    - mod_cloud_notify
     - mod_cloud_notify_extensions
     - mod_cloud_notify_encrypted
     - mod_cloud_notify_priority_tag

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -98,7 +98,6 @@
     - mod_lastlog2
     - mod_limit_auth
     - mod_password_policy
-    - mod_vcard_muc
     - mod_email
     - mod_firewall
     - mod_admin_notify


### PR DESCRIPTION
This removes attempts to load community versions of two things that are
now included in Prosody, which produces warnings in the logs due to
conflicting features.

- Module for group chat avatars
- Push notifications
