### PR TITLE
Silence failure to initialize mod_turn_external when coturn disabled

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -97,7 +97,6 @@ modules_enabled = {
 		"bookmarks";
 		"update_check";
 		"update_notify";
-		"turn_external";
 		"admin_shell";
 		"snikket_client_id";
 		"snikket_ios_preserve_push";
@@ -303,6 +302,9 @@ http_host = DOMAIN
 http_external_url = "https://"..DOMAIN.."/"
 
 if ENV_SNIKKET_TWEAK_TURNSERVER ~= "0" or ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN then
+	modules_enabled: append {
+		"turn_external";
+	}
 	turn_external_host = ENV_SNIKKET_TWEAK_TURNSERVER_DOMAIN or DOMAIN
 	turn_external_port = ENV_SNIKKET_TWEAK_TURNSERVER_PORT
 	turn_external_secret = ENV_SNIKKET_TWEAK_TURNSERVER_SECRET or FileLine("/snikket/prosody/turn-auth-secret-v2")


### PR DESCRIPTION
When the TURN server is disabled with `SNIKKET_TWEAK_TURNSERVER=0` the
following error is logged on startup:

```
b87e815b742b snikket.example.org:turn_external  error  Failed to initialize: the 'turn_external_secret' option is not set in your configuration
```

This silences the error by only loading mod_turn_external when the TURN
server is enabled.
