### PR TITLE
Silence direct usage of the Lua API warnings

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -13,7 +13,7 @@ local UPLOAD_STORAGE_GB = Lua.tonumber(ENV_SNIKKET_UPLOAD_STORAGE_GB);
 
 if Lua.prosody.process_type == "prosody" and not Lua.prosody.config_loaded then
 	-- Wait at startup for certificates
-	local lfs, socket = require "lfs", require "socket";
+	local lfs, socket = Lua.require "lfs", Lua.require "socket";
 	local cert_path = "/etc/prosody/certs/"..DOMAIN..".crt";
 	local counter = 0;
 	while not lfs.attributes(cert_path, "mode") do
@@ -26,7 +26,7 @@ if Lua.prosody.process_type == "prosody" and not Lua.prosody.config_loaded then
 		end
 		socket.sleep(5);
 	end
-	_G.ltn12 = require "ltn12";
+	Lua._G.ltn12 = Lua.require "ltn12";
 end
 
 network_backend = "epoll"


### PR DESCRIPTION
On startup, the following warnings are logged:

```
b87e815b742b startup             info	Hello and welcome to Prosody version trunk nightly build 2000 (2025-06-20, d7e907830260)
b87e815b742b startup             warn	Configuration warning: /etc/prosody/prosody.cfg.lua:16: direct usage of the Lua API is deprecated - replace `require` with `Lua.require`
b87e815b742b startup             warn	Configuration warning: /etc/prosody/prosody.cfg.lua:16: direct usage of the Lua API is deprecated - replace `require` with `Lua.require`
b87e815b742b startup             warn	Configuration warning: /etc/prosody/prosody.cfg.lua:29: direct usage of the Lua API is deprecated - replace `_G` with `Lua._G`
b87e815b742b startup             warn	Configuration warning: /etc/prosody/prosody.cfg.lua:29: direct usage of the Lua API is deprecated - replace `require` with `Lua.require`
```

This silences them by adding the `Lua.` prefix to the config as
suggested.
