### PR TITLE
Clean up unused low port capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
         software-properties-common ca-certificates \
         gpg gpg-agent \
         ansible python3-passlib \
-        libcap2-bin build-essential\
+        build-essential\
     && c_rehash \
     && ansible-playbook -c local -i localhost, --extra-vars "ansible_python_interpreter=/usr/bin/python3" /opt/ansible/snikket.yml \
     && apt-get remove --purge -y \
@@ -36,7 +36,7 @@ RUN apt-get update \
          software-properties-common \
          gpg gpg-agent \
          python3-passlib \
-         libcap2-bin build-essential \
+         build-essential \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/*

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -67,8 +67,6 @@
     name: prosody
     state: stopped
     use: sysvinit
-- name: "Allow Prosody to bind service ports"
-  command: setcap 'cap_net_bind_service=+ep' /usr/bin/lua5.4
 
 - name: "Create Prosody modules source directory"
   file:


### PR DESCRIPTION
Prosody no longer needs to bind low ports since this responsibility was moved to snikket-web-proxy in 6c25508ec2c107a00dd37d3475cc8ca1a6f3a48c

Originally added in 166e000b12d2a2773b3d22bbc209884869f3f2fb
