### PR TITLE
Remove unused variable along with DNS tooling

### DIFF
--- a/ansible/tasks/coturn.yml
+++ b/ansible/tasks/coturn.yml
@@ -6,12 +6,6 @@
     state: present
     install_recommends: yes
 
-- name: "Install dnsutils package"
-  apt:
-    name: dnsutils
-    state: present
-    install_recommends: no
-
 - name: "Disable coturn service"
   service:
     name: coturn

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,10 +16,6 @@ if [ -z "$SNIKKET_SMTP_URL" ]; then
 	SNIKKET_SMTP_URL="smtp://localhost:1025/;no-tls"
 fi
 
-if [ -z "$SNIKKET_EXTERNAL_IP" ]; then
-	SNIKKET_EXTERNAL_IP="$(dig +short $SNIKKET_DOMAIN_ASCII)"
-fi
-
 echo "$SNIKKET_SMTP_URL" | smtp-url-to-msmtp > /etc/msmtprc
 
 echo "from snikket@$SNIKKET_DOMAIN_ASCII" >> /etc/msmtprc


### PR DESCRIPTION
Noticed that `dig` was only used to set the `$SNIKKET_EXTERNAL_IP`
variable and that it wasn't exported or mentioned elsewhere.
