### PR TITLE
Dockerfile: Remove noisy health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ ADD docker/entrypoint.sh /bin/entrypoint.sh
 RUN chmod 770 /bin/entrypoint.sh
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-HEALTHCHECK CMD /usr/bin/prosodyctl shell "portcheck ${SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE:-127.0.0.1}:${SNIKKET_TWEAK_INTERNAL_HTTP_PORT:-5280}"
-
 ADD ansible /opt/ansible
 
 ADD snikket-modules /usr/local/lib/snikket-modules

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -146,7 +146,6 @@ modules_enabled = {
 		"measure_active_users";
 		"measure_lua";
 		"measure_malloc";
-		"portcheck";
 }
 
 registration_watchers = {} -- Disable by default

--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -120,7 +120,6 @@
     - mod_measure_lua
     - mod_measure_malloc
     - mod_http_xep227
-    - mod_portcheck
     - mod_sasl2
     - mod_sasl2_bind2
     - mod_sasl2_sm


### PR DESCRIPTION
Using the Shell causes a lot verbose and scary logging that users
often interpret as being attacked.

Doing health checks via HTTP is unrelaible because of the use of host
networking, where another XMPP server or something already running on
the checked ports being indistinguishable from Snikket running there.
