### PR TITLE
Switch to Lua-SQLite3

### DIFF
--- a/ansible/tasks/prosody.yml
+++ b/ansible/tasks/prosody.yml
@@ -195,9 +195,9 @@
   copy:
     src: ../files/migrator.cfg.lua
     dest: /etc/prosody/migrator.cfg.lua
-- name: "Install LuaDBI driver for SQLite3"
+- name: "Install driver for SQLite3"
   apt:
-    name: lua-dbi-sqlite3
+    name: lua-lsqlite3
     state: present
     install_recommends: no
 


### PR DESCRIPTION
Lua-SQLite3 is available in Debian 13.

- Allows tuning of SQLite3 performance from the Prosody config.
