### PR TITLE
configure Prosody to to bind to localhost (dual stack) instad of just…

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -158,7 +158,7 @@ contact_info = {
 }
 
 http_ports  = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_PORT or 5280 }
-http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "127.0.0.1" }
+http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "localhost" }
 http_max_content_size = 1024 * 1024 -- non-streaming uploads limited to 1MB (improves RAM usage)
 
 https_ports = {};

--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -158,7 +158,7 @@ contact_info = {
 }
 
 http_ports  = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_PORT or 5280 }
-http_interfaces = { ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE or "localhost" }
+http_interfaces = split(ENV_SNIKKET_TWEAK_INTERNAL_HTTP_INTERFACE)
 http_max_content_size = 1024 * 1024 -- non-streaming uploads limited to 1MB (improves RAM usage)
 
 https_ports = {};


### PR DESCRIPTION
… 127.0.0.1 by default  (https://github.com/snikket-im/snikket-web-proxy/issues/28)