### PR TITLE
Use Retention Days settings also for MUCs

### DIFF
--- a/ansible/files/prosody.cfg.lua
+++ b/ansible/files/prosody.cfg.lua
@@ -396,6 +396,9 @@ Component ("groups."..DOMAIN) "muc"
 
 	restrict_room_creation = "local"
 
+	-- Remove archived messages in MUC after N days
+	muc_log_expires_after = ("%dd"):format(RETENTION_DAYS)
+
 	-- Some older deployments may have the general@ MUC, so we still need
 	-- to protect it:
 	muc_local_only = { "general@groups."..DOMAIN }


### PR DESCRIPTION
The SNIKKET_RETENTION_DAYS setting has not been used for MAM in MUCs.