### PR TITLE
mod_invites_default_group: additional_data typo

### DIFF
--- a/snikket-modules/mod_invites_default_group/mod_invites_default_group.lua
+++ b/snikket-modules/mod_invites_default_group/mod_invites_default_group.lua
@@ -3,7 +3,7 @@
 module:hook("invite-created", function (invite)
 	if invite.type == "roster"
 	and not (invite.additional_data and invite.additional_data.groups) then
-		if not invite.addititional_data then
+		if not invite.additional_data then
 			invite.additional_data = {};
 		end
 		invite.additional_data.groups = { "default" };


### PR DESCRIPTION
The invites always carry the table, that's why it never caused any issues I guess. But nonetheless a potential bug.